### PR TITLE
glossary: fix the suggestion URL which turned invalid after file reorg

### DIFF
--- a/pages/database-glossary/index.vue
+++ b/pages/database-glossary/index.vue
@@ -149,7 +149,7 @@
           </h2>
           <div class="text-right">
             <a
-              href="https://github.com/bytebase/bytebase.com/edit/main/pages/glossary.ts"
+              href="https://github.com/bytebase/bytebase.com/edit/main/common/glossary.ts"
               target="__blank"
               class="text-sm text-blue-600 hover:underline"
               >Suggest changes on GitHub</a


### PR DESCRIPTION
I tried to suggest some changes on the [Database Glossary page](https://bytebase.com/database-glossary) and found the suggestion URL invalid. I checked the commit history for bytebase.com/pages/database-glossary, and according to the PR ["Move to database-glossary sub folder"](https://github.com/bytebase/bytebase.com/commit/5a5382322f3b7f286acf2bac7fb82b960ac7dee0#diff-20abb46be334ff13b26d2358db5a806b6cc99c118ead6d52adf2e99ce4532b88) I identified the valid URL.