### PR TITLE
feat: overview page unclickable

### DIFF
--- a/components/DocsSidebar.vue
+++ b/components/DocsSidebar.vue
@@ -28,10 +28,15 @@
         class="pl-3"
         @click="handleLinkClick"
       >
+        <span
+          v-if="node.document.hide"
+          class="pl-3 pr-1 py-2 block flex-shrink-0 text-gray-600 mt-4 font-bold w-full text-sm border border-transparent border-r-0 whitespace-pre-wrap hover:text-gray-700"
+          >{{ node.document.title }}</span
+        >
         <NuxtLink
+          v-else
           :to="{ path: `/docs${node.document.path}` }"
-          class="pl-3 pr-1 py-2 block flex-shrink-0 text-gray-500 w-full text-sm border border-transparent border-r-0 whitespace-pre-wrap hover:text-gray-700"
-          :class="'text-gray-600 mt-4 font-bold'"
+          class="pl-3 pr-1 py-2 block flex-shrink-0 text-gray-600 mt-4 font-bold w-full text-sm border border-transparent border-r-0 whitespace-pre-wrap hover:text-gray-700"
         >
           <span>{{ node.document.title }}</span>
         </NuxtLink>
@@ -119,6 +124,8 @@ import { useStore } from "~/store";
 
 interface ContentDocument extends IContentDocument {
   order: number;
+  description?: string;
+  hide?: boolean;
 }
 
 interface Document extends ContentDocument {

--- a/components/DocsSidebar.vue
+++ b/components/DocsSidebar.vue
@@ -29,7 +29,7 @@
         @click="handleLinkClick"
       >
         <span
-          v-if="node.document.hide"
+          v-if="node.document.isHeader"
           class="pl-3 pr-1 py-2 block flex-shrink-0 text-gray-600 mt-4 font-bold w-full text-sm border border-transparent border-r-0 whitespace-pre-wrap hover:text-gray-700"
           >{{ node.document.title }}</span
         >
@@ -125,7 +125,7 @@ import { useStore } from "~/store";
 interface ContentDocument extends IContentDocument {
   order: number;
   description?: string;
-  hide?: boolean;
+  isHeader?: boolean;
 }
 
 interface Document extends ContentDocument {

--- a/components/DocumentViewer.vue
+++ b/components/DocumentViewer.vue
@@ -78,6 +78,7 @@ import {
   onMounted,
   reactive,
   ref,
+  useMeta,
 } from "@nuxtjs/composition-api";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
@@ -105,6 +106,7 @@ export default defineComponent({
     next: Object,
   },
   setup(props) {
+    const meta = useMeta({});
     const state = reactive<State>({
       currentHashId: "",
     });
@@ -123,7 +125,22 @@ export default defineComponent({
     });
 
     onMounted(() => {
-      window.document.title = props.document?.title || "Bytebase Document";
+      // Dynamicly set metadata.
+      meta.title.value = props.document?.title || "Bytebase Document";
+      meta.meta.value = [
+        {
+          hid: "description",
+          name: "description",
+          content:
+            props.document?.description ||
+            (ducumentContainerRef.value?.textContent || "")
+              ?.replaceAll(/\r?\n/g, " ")
+              .replaceAll(/\s+/g, " ")
+              .slice(meta.title.value?.length, 128)
+              .trim() + "...",
+        },
+      ];
+
       const hashTags = ducumentContainerRef.value?.querySelectorAll("h2,h3");
       if (hashTags && hashTags.length > 0) {
         const tagElementList = Array.from(hashTags) as HTMLElement[];
@@ -159,6 +176,7 @@ export default defineComponent({
       updatedTsFromNow,
     };
   },
+  head: {},
 });
 </script>
 

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -1,7 +1,7 @@
 ---
 title: 📚 Concepts
 order: 20000
-hide: true
+isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -1,6 +1,7 @@
 ---
 title: 📚 Concepts
 order: 20000
+hide: true
 ---
 
-# 📚 Concepts
+<!-- Do not show this page -->

--- a/docs/document-write-guide.md
+++ b/docs/document-write-guide.md
@@ -1,5 +1,6 @@
 ---
 title: ✍️ Document write guide
+description: This section shows the steps of writing a document. It's a little different from a common Markdown file. In order not to involve changes to code files, we need to save its metadata between the `--- xxx ---`.
 order: -1
 ---
 

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -1,8 +1,7 @@
 ---
 title: ✨ Features
 order: 30000
+hide: true
 ---
 
-# ✨ Features
-
-This is overview page of all features.
+<!-- Do not show this page -->

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -1,7 +1,7 @@
 ---
 title: ✨ Features
 order: 30000
-hide: true
+isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/install/overview.md
+++ b/docs/install/overview.md
@@ -1,7 +1,7 @@
 ---
 title: 🚀 Install
 order: 10000
-hide: true
+isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/install/overview.md
+++ b/docs/install/overview.md
@@ -1,11 +1,7 @@
 ---
 title: 🚀 Install
 order: 10000
+hide: true
 ---
 
-# 🚀 Install
-
-Let's see how to install bytebase:
-
-- [Install with Docker](/docs/install/install-with-docker)
-- [Build from source](/docs/install/build-from-source)
+<!-- Do not show this page -->

--- a/docs/operating/overview.md
+++ b/docs/operating/overview.md
@@ -1,7 +1,7 @@
 ---
 title: 🔧 Operating
 order: 60000
-hide: true
+isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/operating/overview.md
+++ b/docs/operating/overview.md
@@ -1,6 +1,7 @@
 ---
 title: 🔧 Operating
 order: 60000
+hide: true
 ---
 
-# 🔧 Operating
+<!-- Do not show this page -->

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -1,6 +1,7 @@
 ---
 title: 📖 Reference
 order: 70000
+hide: true
 ---
 
-# 📖 Reference
+<!-- Do not show this page -->

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -1,7 +1,7 @@
 ---
 title: 📖 Reference
 order: 70000
-hide: true
+isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/settings/overview.md
+++ b/docs/settings/overview.md
@@ -1,6 +1,7 @@
 ---
 title: ⚙️ Settings
 order: 50000
+hide: true
 ---
 
-# ⚙️ Settings
+<!-- Do not show this page -->

--- a/docs/settings/overview.md
+++ b/docs/settings/overview.md
@@ -1,7 +1,7 @@
 ---
 title: ⚙️ Settings
 order: 50000
-hide: true
+isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/use-bytebase/overview.md
+++ b/docs/use-bytebase/overview.md
@@ -1,6 +1,7 @@
 ---
 title: 🧭 Use Bytebase
 order: 40000
+hide: true
 ---
 
-# 🧭 Use Bytebase
+<!-- Do not show this page -->

--- a/docs/use-bytebase/overview.md
+++ b/docs/use-bytebase/overview.md
@@ -1,7 +1,7 @@
 ---
 title: 🧭 Use Bytebase
 order: 40000
-hide: true
+isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/what-is-bytebase.md
+++ b/docs/what-is-bytebase.md
@@ -1,5 +1,6 @@
 ---
 title: 👀 What is Bytebase
+description: Bytebase is a database schema change and version control management tool for teams. It consists of a web console and a backend. The backend has a migration core to manage database schema changes. It also integrates with VCS to enable version controlled schema management.
 order: 0
 ---
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -39,6 +39,7 @@ function databaseVCSRouteList() {
 const docsRouteList = async () => {
   const { $content } = require("@nuxt/content");
   const documentList = await $content("", { deep: true })
+    .where({ hide: { $ne: true } })
     .sortBy("order")
     .fetch();
   const routeList = [];

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -39,7 +39,7 @@ function databaseVCSRouteList() {
 const docsRouteList = async () => {
   const { $content } = require("@nuxt/content");
   const documentList = await $content("", { deep: true })
-    .where({ hide: { $ne: true } })
+    .where({ isHeader: { $ne: true } })
     .sortBy("order")
     .fetch();
   const routeList = [];

--- a/pages/docs/_category/_document.vue
+++ b/pages/docs/_category/_document.vue
@@ -17,9 +17,15 @@ export default {
     }
 
     const [prev, next] = await $content("", { deep: true })
+      .where({ hide: { $ne: true } })
       .sortBy("order")
       .surround(path)
       .fetch();
+
+    if (path.endsWith("/overview")) {
+      // The first level overview document isn't clickable, redirect it to /docs.
+      redirect("/docs");
+    }
 
     return {
       document,

--- a/pages/docs/_category/_document.vue
+++ b/pages/docs/_category/_document.vue
@@ -17,7 +17,7 @@ export default {
     }
 
     const [prev, next] = await $content("", { deep: true })
-      .where({ hide: { $ne: true } })
+      .where({ isHeader: { $ne: true } })
       .sortBy("order")
       .surround(path)
       .fetch();

--- a/pages/docs/_category/_subcategory/_document.vue
+++ b/pages/docs/_category/_subcategory/_document.vue
@@ -17,6 +17,7 @@ export default {
     }
 
     const [prev, next] = await $content("", { deep: true })
+      .where({ hide: { $ne: true } })
       .sortBy("order")
       .surround(path)
       .fetch();

--- a/pages/docs/_category/_subcategory/_document.vue
+++ b/pages/docs/_category/_subcategory/_document.vue
@@ -17,7 +17,7 @@ export default {
     }
 
     const [prev, next] = await $content("", { deep: true })
-      .where({ hide: { $ne: true } })
+      .where({ isHeader: { $ne: true } })
       .sortBy("order")
       .surround(path)
       .fetch();

--- a/pages/docs/_slug.vue
+++ b/pages/docs/_slug.vue
@@ -17,6 +17,7 @@ export default {
     }
 
     const [prev, next] = await $content("", { deep: true })
+      .where({ hide: { $ne: true } })
       .sortBy("order")
       .surround(path)
       .fetch();

--- a/pages/docs/_slug.vue
+++ b/pages/docs/_slug.vue
@@ -17,7 +17,7 @@ export default {
     }
 
     const [prev, next] = await $content("", { deep: true })
-      .where({ hide: { $ne: true } })
+      .where({ isHeader: { $ne: true } })
       .sortBy("order")
       .surround(path)
       .fetch();


### PR DESCRIPTION
* Add `hide` field to make doc unclickable into `.md` fields;
* Add `description` field to dynamic generate page metadata. And it's optional right now(I just write two example description for "/docs/what-is-bytebase" and "/docs/document-write-guide", maybe @bytebase/bytebase-devrel could help finish this). If it is null, this field would be a slice string of document content.