### PR TITLE
docs: Use “Hidden” instead of “Chinese” tag to hide post

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -125,7 +125,7 @@ export default {
         "Changelog",
         "Announcement",
         "Education",
-        "Chinese",
+        "Hidden",
       ]);
       for (const post of postList) {
         if (post.tags.find((item) => item.name == "Changelog")) {


### PR DESCRIPTION
We are going to hide non-chinese post which is only searchable by the search engine