### PR TITLE
feat: include-block

### DIFF
--- a/components/DocumentViewer.vue
+++ b/components/DocumentViewer.vue
@@ -209,16 +209,14 @@ export default defineComponent({
 </script>
 
 <style>
+@import "~/assets/css/github-markdown-style.css";
+
 .nuxt-content .nuxt-content-highlight {
   @apply relative;
 }
 .nuxt-content .copy-btn {
   @apply absolute top-0.5 right-0.5 text-xs px-1 italic bg-gray-200 rounded opacity-60 hover:opacity-100;
 }
-</style>
-
-<style scoped>
-@import "~/assets/css/github-markdown-style.css";
 
 .nuxt-content h2 > a:first-child:before,
 .nuxt-content h3 > a:first-child:before {

--- a/components/IncludeBlock.vue
+++ b/components/IncludeBlock.vue
@@ -1,0 +1,72 @@
+<template>
+  <div ref="containerRef" class="w-full"></div>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  onMounted,
+  useContext,
+  ref,
+} from "@nuxtjs/composition-api";
+import { ContentDocument, DocumentBodyNode } from "~/types/docs";
+
+const renderContentObjectToElement = (
+  contentObject: DocumentBodyNode,
+  element: HTMLElement
+) => {
+  if (contentObject.type === "root") {
+    for (const node of contentObject.children) {
+      renderContentObjectToElement(node, element);
+    }
+  } else if (contentObject.type === "text") {
+    const textNode = document.createTextNode(contentObject.value);
+    element.appendChild(textNode);
+  } else {
+    const childElement = document.createElement(contentObject.tag);
+    for (const attr in contentObject.props) {
+      if (attr === "className") {
+        childElement.setAttribute("class", contentObject.props[attr].join(" "));
+      } else {
+        childElement.setAttribute(attr, contentObject.props[attr]);
+      }
+    }
+    for (const node of contentObject.children) {
+      renderContentObjectToElement(node, childElement);
+    }
+    element.appendChild(childElement);
+  }
+};
+
+export default defineComponent({
+  props: {
+    url: {
+      type: String,
+      default: "info",
+    },
+  },
+  setup(props) {
+    const { $content } = useContext();
+    const containerRef = ref<HTMLDivElement>();
+
+    onMounted(async () => {
+      try {
+        const document = (await $content(props.url, { deep: true })
+          .sortBy("order")
+          .limit(1)
+          .fetch()) as any as ContentDocument;
+
+        if (document && containerRef.value) {
+          renderContentObjectToElement(document.body, containerRef.value);
+        }
+      } catch (error) {
+        // Do nothing when cannot find the document.
+      }
+    });
+
+    return {
+      containerRef,
+    };
+  },
+});
+</script>

--- a/types/docs.d.ts
+++ b/types/docs.d.ts
@@ -1,6 +1,15 @@
 import { IContentDocument } from "@nuxt/content/types/content";
 
+interface DocumentBodyNode {
+  type: string;
+  value: string;
+  tag: string;
+  children: DocumentBodyNode[];
+  props: any;
+}
+
 interface ContentDocument extends IContentDocument {
+  body: DocumentBodyNode;
   order: number;
   description?: string;
   isHeader?: boolean;


### PR DESCRIPTION
New atom component `IncludeBlock` for rendering other markdowns directly. Usage:

```markdown
...
## 👋🏼 Introduction

<include-block url="features/archive"></include-block>

Bytebase is a database schema change and version control management tool for teams.
...
```