### PR TITLE
feat: use `_layout.md` to sort docs

### DIFF
--- a/components/DocumentViewer.vue
+++ b/components/DocumentViewer.vue
@@ -31,7 +31,7 @@
       >
         <NuxtLink
           v-if="prev"
-          :to="localePath(`/docs${removeI18nPrefixPath(prev.path)}`)"
+          :to="localePath(`/docs${prev.path}`)"
           class="py-2 flex flex-row justify-start items-center text-sm text-gray-600 hover:text-black"
         >
           <img class="h-3 mr-2" src="~/assets/svg/arrow-left.svg" alt="prev" />
@@ -40,7 +40,7 @@
         <span v-else></span>
         <NuxtLink
           v-if="next"
-          :to="localePath(`/docs${removeI18nPrefixPath(next.path)}`)"
+          :to="localePath(`/docs${next.path}`)"
           class="py-2 flex flex-row justify-end items-center text-sm text-gray-600 hover:text-black"
         >
           <span>{{ next ? next.title : "" }}</span>
@@ -98,12 +98,13 @@ import {
   onMounted,
   reactive,
   ref,
+  useContext,
   useMeta,
 } from "@nuxtjs/composition-api";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
+import { ContentDocument } from "~/types/docs";
 import storage from "../common/storage";
-import { removeI18nPrefixPath } from "../common/utils";
 import SubscribeSection from "./SubscribeSection.vue";
 dayjs.extend(relativeTime);
 
@@ -127,10 +128,9 @@ export default defineComponent({
       default: "",
     },
     document: Object,
-    prev: Object,
-    next: Object,
   },
   setup(props) {
+    const { $content, app } = useContext();
     const meta = useMeta({});
     const state = reactive<State>({
       currentHashId: "",
@@ -149,8 +149,48 @@ export default defineComponent({
     const updatedTsFromNow = computed(() => {
       return dayjs(props.document?.updatedAt).fromNow();
     });
+    const prev = ref<any>(undefined);
+    const next = ref<any>(undefined);
 
-    onMounted(() => {
+    onMounted(async () => {
+      const layout = (await $content(
+        app.i18n.locale,
+        "_layout"
+      ).fetch()) as any as ContentDocument;
+      const nodes = layout.body.children
+        .filter((n) => n.tag === "h2" || n.tag === "h3" || n.tag === "h4")
+        .map((n) => {
+          let level = 1;
+          if (n.tag === "h3") {
+            level = 2;
+          } else if (n.tag === "h4") {
+            level = 3;
+          }
+
+          const child = n.children[1];
+          let path = undefined;
+          let title = "";
+          if (child.type !== "text") {
+            path = child.props.to;
+            title = child.children[0].value;
+          } else {
+            title = child.value;
+          }
+
+          return {
+            level,
+            title,
+            path,
+          };
+        })
+        .filter((n) => n.path !== undefined);
+
+      const index = nodes.findIndex((n) =>
+        props?.document?.path.endsWith(n.path)
+      );
+      prev.value = nodes[index - 1];
+      next.value = nodes[index + 1];
+
       // Dynamicly set metadata.
       meta.title.value = props.document?.title || "Bytebase Document";
       meta.meta.value = [
@@ -249,13 +289,14 @@ export default defineComponent({
 
     return {
       state,
+      prev,
+      next,
       toc,
       ducumentContainerRef,
       filePath,
       updatedTsFromNow,
       onCloseSubscribtionPopUp,
       onSubscribed,
-      removeI18nPrefixPath,
     };
   },
   head: {},

--- a/components/IncludeBlock.vue
+++ b/components/IncludeBlock.vue
@@ -51,8 +51,7 @@ export default defineComponent({
 
     onMounted(async () => {
       try {
-        const document = (await $content(props.url, { deep: true })
-          .sortBy("order")
+        const document = (await $content(props.url)
           .limit(1)
           .fetch()) as any as ContentDocument;
 

--- a/components/SearchDocsDialog.vue
+++ b/components/SearchDocsDialog.vue
@@ -85,7 +85,6 @@ import { useStore } from "~/store";
 
 interface ContentDocument extends IContentDocument {
   title: string;
-  order: number;
 }
 
 export default defineComponent({
@@ -99,9 +98,9 @@ export default defineComponent({
     const showSearchDialogFlag = computed(() => store.showSearchDialogFlag);
 
     onMounted(async () => {
-      const data = (await $content("", { deep: true })
-        .sortBy("order")
-        .fetch()) as any as ContentDocument[];
+      const data = (await $content("", {
+        deep: true,
+      }).fetch()) as any as ContentDocument[];
 
       for (const document of data) {
         documentList.push(document);

--- a/docs/en/_layout.md
+++ b/docs/en/_layout.md
@@ -1,0 +1,127 @@
+# docs_layout
+
+## [👀 What is Bytebase](/what-is-bytebase)
+
+## Install
+
+### [Docker (5 seconds)](/install/install-with-docker)
+
+### [Build from Source](/install/build-from-source)
+
+### [Use External PostgreSQL Database](/install/external-postgres)
+
+## 📚 Concepts
+
+### [Data Model](/concepts/data-model)
+
+### [Roles and Permissions](/concepts/roles-and-permissions)
+
+### [Schema Change Workflow](/concepts/schema-change-workflow)
+
+### [Migration Types](/concepts/migration-types)
+
+### [Tenant Database](/concepts/tenant-database)
+
+## ✨ Features
+
+### [SQL Review](/features/sql-review)
+
+### [Version Control (GitOps)](/features/version-control)
+
+### [Tenant Database Management](/features/tenant-database-management)
+
+### [SQL Editor](/features/sql-editor/overview)
+
+#### [Compose a Query](/features/sql-editor/writing-a-query)
+
+#### [Run and EXPLAIN Query](/features/sql-editor/run-queries)
+
+#### [Query Results](/features/sql-editor/query-results)
+
+#### [Explore the Schema](/features/sql-editor/explore-the-schema)
+
+#### [Saved Sheet and Query History](/features/sql-editor/never-miss-your-works)
+
+#### [Share Sheet with Teammates](/features/sql-editor/share-sheet-with-teammates)
+
+### [SQL Advisor](/features/sql-advisor/overview)
+
+#### [Backward Compatibility Migration Check](/features/sql-advisor/backward-compatibility-migration-check)
+
+### [Migration History](/features/migration-history)
+
+### [Drift Detection](/features/drift-detection)
+
+### [Backup and Restore](/features/backup-and-restore)
+
+### [Anomaly Center](/features/anomaly-center)
+
+### [Webhook](/features/webhook)
+
+### [Archive](/features/archive)
+
+## 🧭 Use Bytebase
+
+### [SQL Review Interface](/use-bytebase/sql-review-interface/overview)
+
+#### [Create the SQL review ticket](/use-bytebase/sql-review-interface/create-the-sql-review-ticket)
+
+### [VCS Integration (GitOps)](/use-bytebase/vcs-integration/overview)
+
+#### [Add Git Provider](/use-bytebase/vcs-integration/add-git-provider)
+
+#### [Enable Version Control Workflow (GitOps) in Project](/use-bytebase/vcs-integration/enable-version-control-workflow)
+
+#### [Name and Organize Schema Files](/use-bytebase/vcs-integration/name-and-organize-schema-files)
+
+#### [Create the First Baseline Migration](/use-bytebase/vcs-integration/create-the-first-baseline-migration)
+
+#### [🐞 Troubleshoot](/use-bytebase/vcs-integration/troubleshoot)
+
+### [Backup and Restore Database](/use-bytebase/backup-restore-database/overview)
+
+#### [Backup](/use-bytebase/backup-restore-database/backup)
+
+#### [Restore from Backup](/use-bytebase/backup-restore-database/restore-from-backup)
+
+### [Environment Policy](/use-bytebase/environment-policy/overview)
+
+#### [Approval Policy](/use-bytebase/environment-policy/approval-policy)
+
+#### [Backup Schedule Policy](/use-bytebase/environment-policy/backup-schedule-policy)
+
+### [Webhook Integration](/use-bytebase/webhook-integration/overview)
+
+#### [Project Webhook](/use-bytebase/webhook-integration/project-webhook)
+
+#### [Database Webhook](/use-bytebase/webhook-integration/database-webhook)
+
+## ⚙️ Settings
+
+### [Link External SQL Console](/settings/external-sql-console)
+
+## 🔧 Operating
+
+### [Production Setup](/operating/production-setup)
+
+### [Disaster Recovery](/operating/disaster-recovery)
+
+### [Telemetry](/operating/telemetry)
+
+## 📖 Reference
+
+### [Server Startup Options](/reference/command-line)
+
+## [Error Code](/error-code)
+
+## Troubleshooting
+
+### [How to perform upgrade](/troubleshooting/how-to-perform-upgrade)
+
+### [How to solve OAuth CORS error with old GitLab version](/troubleshooting/how-to-solve-oauth-cors-error-with-old-gitlab-version)
+
+### [Unable to start Bytebase with Docker](/troubleshooting/unable-to-start-bytebase-with-docker)
+
+## [FAQ](/faq)
+
+## [✍️ Document write guide](/document-write-guide)

--- a/docs/en/concepts/data-model.md
+++ b/docs/en/concepts/data-model.md
@@ -1,6 +1,5 @@
 ---
 title: Data Model
-order: 20100
 ---
 
 # Data Model

--- a/docs/en/concepts/migration-types.md
+++ b/docs/en/concepts/migration-types.md
@@ -1,6 +1,5 @@
 ---
 title: Migration Types
-order: 20400
 ---
 
 # Migration Types

--- a/docs/en/concepts/overview.md
+++ b/docs/en/concepts/overview.md
@@ -1,7 +1,5 @@
 ---
 title: 📚 Concepts
-order: 20000
-isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/en/concepts/roles-and-permissions.md
+++ b/docs/en/concepts/roles-and-permissions.md
@@ -1,6 +1,5 @@
 ---
 title: Roles and Permissions
-order: 20200
 ---
 
 # Roles and Permissions

--- a/docs/en/concepts/schema-change-workflow.md
+++ b/docs/en/concepts/schema-change-workflow.md
@@ -1,6 +1,5 @@
 ---
 title: Schema Change Workflow
-order: 20300
 ---
 
 # Schema Change Workflow

--- a/docs/en/concepts/tenant-database.md
+++ b/docs/en/concepts/tenant-database.md
@@ -1,6 +1,5 @@
 ---
 title: Tenant Database
-order: 20400
 ---
 
 # Tenant Database

--- a/docs/en/document-write-guide.md
+++ b/docs/en/document-write-guide.md
@@ -1,7 +1,6 @@
 ---
 title: ✍️ Document write guide
-description: This section shows the steps of writing a document. It's a little different from a common Markdown file. In order not to involve changes to code files, we need to save its metadata between the `--- xxx ---`.
-order: 999999
+description: This section shows the steps of writing a document.
 ---
 
 # ✍️ Document write guide
@@ -13,7 +12,7 @@ This section shows the steps of writing a document.
 ```markdown
 ---
 title: Document write guide
-order: 40100
+description: This section shows the steps of writing a document.
 ---
 
 # How to write a document?
@@ -21,23 +20,19 @@ order: 40100
 Firstly you need to write down the main concept of your documention.
 ```
 
-It's a little different from a common Markdown file. In order not to involve changes to code files, we need to save its metadata between the `--- xxx ---` block. Typically used fields are:
+For optimizing documentation SEO, we need to save its metadata between the `--- xxx ---` block. Typically used fields are:
 
-- `title` is the display text in sidebar;
-- `order` indicates the display order. It is an integer representing an array of three two-digit numbers: `{{category}}{{subcategory}}{{document}}`. **We support up to three folder structure. And the sub-directory structure determines the hierarchy.**
-
-  For example, [Build from Source](/docs/install/build-from-source) is `10200` which can be `[1][2][0]`. This means that it's the second in the category, the third in the subcategory and the first in the leaf.
+- `title` should be same as the header title;
+- `description` field should be the excerpt of the document;
 
 ## How to write a new document?
 
 1. Write the full content in any editor that supports Markdown. e.g. [VSCode](https://code.visualstudio.com/)/[typora](https://typora.io/)
-2. Think about where the article should be displayed in sidebar.
-3. Follow the [example](#the-structure-of-md-file) to figure out the `order` value.
-4. Add the metadata block at the top of the markdown file.
-5. Refer to an existing structure, put the file under a folder of `./docs/`.
-6. Run `pnpm dev` start the review server.
-7. Go to [localhost:3000/docs](http://localhost:3000/docs) and check your creation.
-8. If everything is fine, create a new PR with the changes to [our repo in GitHub](https://github.com/bytebase/bytebase.com).
+2. Add the metadata block at the top of the markdown file.
+3. Add an entry for the document in `_layout.md`.
+4. Run `pnpm dev` start the review server.
+5. Go to [localhost:3000/docs](http://localhost:3000/docs) and check your creation.
+6. If everything is fine, create a new PR with the changes to [our repo in GitHub](https://github.com/bytebase/bytebase.com).
 
 ## Using powerful components into Markdown
 

--- a/docs/en/error-code.md
+++ b/docs/en/error-code.md
@@ -1,6 +1,5 @@
 ---
 title: Error Code
-order: 80000
 ---
 
 # Error Code

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -1,6 +1,5 @@
 ---
 title: FAQ
-order: 100000
 ---
 
 # FAQ

--- a/docs/en/features/anomaly-center.md
+++ b/docs/en/features/anomaly-center.md
@@ -1,6 +1,5 @@
 ---
 title: Anomaly Center
-order: 30900
 ---
 
 # Anomaly Center

--- a/docs/en/features/archive.md
+++ b/docs/en/features/archive.md
@@ -1,6 +1,5 @@
 ---
 title: Archive
-order: 31100
 ---
 
 # Archive

--- a/docs/en/features/backup-and-restore.md
+++ b/docs/en/features/backup-and-restore.md
@@ -1,6 +1,5 @@
 ---
 title: Backup and Restore
-order: 30800
 ---
 
 # Backup and Restore

--- a/docs/en/features/drift-detection.md
+++ b/docs/en/features/drift-detection.md
@@ -1,6 +1,5 @@
 ---
 title: Drift Detection
-order: 30700
 ---
 
 # Drift Detection

--- a/docs/en/features/migration-history.md
+++ b/docs/en/features/migration-history.md
@@ -1,6 +1,5 @@
 ---
 title: Migration History
-order: 30600
 ---
 
 # Migration History

--- a/docs/en/features/overview.md
+++ b/docs/en/features/overview.md
@@ -1,7 +1,5 @@
 ---
 title: ✨ Features
-order: 30000
-isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/en/features/sql-advisor/backward-compatibility-migration-check.md
+++ b/docs/en/features/sql-advisor/backward-compatibility-migration-check.md
@@ -1,6 +1,5 @@
 ---
 title: Backward Compatibility Migration Check
-order: 30501
 ---
 
 # Backward Compatibility Migration Check

--- a/docs/en/features/sql-advisor/overview.md
+++ b/docs/en/features/sql-advisor/overview.md
@@ -1,6 +1,5 @@
 ---
 title: SQL Advisor
-order: 30500
 ---
 
 # SQL Advisor

--- a/docs/en/features/sql-editor/explore-the-schema.md
+++ b/docs/en/features/sql-editor/explore-the-schema.md
@@ -1,6 +1,5 @@
 ---
 title: Explore the Schema
-order: 30404
 ---
 
 # Explore the Schema

--- a/docs/en/features/sql-editor/never-miss-your-works.md
+++ b/docs/en/features/sql-editor/never-miss-your-works.md
@@ -1,6 +1,5 @@
 ---
 title: Saved Sheet and Query History
-order: 30405
 ---
 
 # Saved Sheet and Query History

--- a/docs/en/features/sql-editor/overview.md
+++ b/docs/en/features/sql-editor/overview.md
@@ -1,6 +1,5 @@
 ---
 title: SQL Editor
-order: 30400
 ---
 
 # SQL Editor

--- a/docs/en/features/sql-editor/query-results.md
+++ b/docs/en/features/sql-editor/query-results.md
@@ -1,6 +1,5 @@
 ---
 title: Query Results
-order: 30403
 ---
 
 # Query Results

--- a/docs/en/features/sql-editor/run-queries.md
+++ b/docs/en/features/sql-editor/run-queries.md
@@ -1,6 +1,5 @@
 ---
 title: Run and EXPLAIN Query
-order: 30402
 ---
 
 # Run and EXPLAIN Query

--- a/docs/en/features/sql-editor/share-sheet-with-teammates.md
+++ b/docs/en/features/sql-editor/share-sheet-with-teammates.md
@@ -1,6 +1,5 @@
 ---
 title: Share Sheet with Teammates
-order: 30406
 ---
 
 # Share Sheet with Teammates

--- a/docs/en/features/sql-editor/writing-a-query.md
+++ b/docs/en/features/sql-editor/writing-a-query.md
@@ -1,6 +1,5 @@
 ---
 title: Compose a Query
-order: 30401
 ---
 
 # Compose a Query

--- a/docs/en/features/sql-review.md
+++ b/docs/en/features/sql-review.md
@@ -1,6 +1,5 @@
 ---
 title: SQL Review
-order: 30100
 ---
 
 # SQL Review

--- a/docs/en/features/tenant-database-management.md
+++ b/docs/en/features/tenant-database-management.md
@@ -1,6 +1,5 @@
 ---
 title: Tenant Database Management
-order: 30300
 ---
 
 # Tenant Database Management

--- a/docs/en/features/version-control.md
+++ b/docs/en/features/version-control.md
@@ -1,6 +1,5 @@
 ---
 title: Version Control (GitOps)
-order: 30200
 ---
 
 # Version Control (GitOps)

--- a/docs/en/features/webhook.md
+++ b/docs/en/features/webhook.md
@@ -1,6 +1,5 @@
 ---
 title: Webhook
-order: 31000
 ---
 
 # Webhook

--- a/docs/en/install/build-from-source.md
+++ b/docs/en/install/build-from-source.md
@@ -1,6 +1,5 @@
 ---
 title: Build from Source
-order: 10200
 ---
 
 # Build from Source

--- a/docs/en/install/external-postgres.md
+++ b/docs/en/install/external-postgres.md
@@ -1,6 +1,5 @@
 ---
 title: Use External PostgreSQL Database
-order: 10300
 ---
 
 # Use External PostgreSQL Database

--- a/docs/en/install/install-with-docker.md
+++ b/docs/en/install/install-with-docker.md
@@ -1,6 +1,5 @@
 ---
 title: Docker (5 seconds)
-order: 10100
 ---
 
 # Docker (5 seconds)

--- a/docs/en/install/overview.md
+++ b/docs/en/install/overview.md
@@ -1,7 +1,5 @@
 ---
 title: 🚀 Install
-order: 10000
-isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/en/operating/disaster-recovery.md
+++ b/docs/en/operating/disaster-recovery.md
@@ -1,6 +1,5 @@
 ---
 title: Disaster Recovery
-order: 60200
 ---
 
 # Disaster Recovery

--- a/docs/en/operating/overview.md
+++ b/docs/en/operating/overview.md
@@ -1,7 +1,5 @@
 ---
 title: 🔧 Operating
-order: 60000
-isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/en/operating/production-setup.md
+++ b/docs/en/operating/production-setup.md
@@ -1,6 +1,5 @@
 ---
 title: Production Setup
-order: 60100
 ---
 
 # Production Setup

--- a/docs/en/operating/telemetry.md
+++ b/docs/en/operating/telemetry.md
@@ -1,6 +1,5 @@
 ---
 title: Telemetry
-order: 60300
 ---
 
 # Telemetry

--- a/docs/en/reference/command-line.md
+++ b/docs/en/reference/command-line.md
@@ -1,6 +1,5 @@
 ---
 title: Server Startup Options
-order: 70100
 ---
 
 # Server Startup Options

--- a/docs/en/reference/overview.md
+++ b/docs/en/reference/overview.md
@@ -1,7 +1,5 @@
 ---
 title: 📖 Reference
-order: 70000
-isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/en/settings/external-sql-console.md
+++ b/docs/en/settings/external-sql-console.md
@@ -1,6 +1,5 @@
 ---
 title: Link External SQL Console
-order: 50100
 ---
 
 # Link External SQL Console

--- a/docs/en/settings/overview.md
+++ b/docs/en/settings/overview.md
@@ -1,7 +1,5 @@
 ---
 title: ⚙️ Settings
-order: 50000
-isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/en/troubleshooting/how-to-perform-upgrade.md
+++ b/docs/en/troubleshooting/how-to-perform-upgrade.md
@@ -1,6 +1,5 @@
 ---
 title: How to perform upgrade
-order: 90100
 ---
 
 # How to perform upgrade

--- a/docs/en/troubleshooting/how-to-solve-oauth-cors-error-with-old-gitlab-version.md
+++ b/docs/en/troubleshooting/how-to-solve-oauth-cors-error-with-old-gitlab-version.md
@@ -1,6 +1,5 @@
 ---
 title: How to solve OAuth CORS error with old GitLab version
-order: 90200
 ---
 
 # How to solve OAuth CORS error with old GitLab version

--- a/docs/en/troubleshooting/overview.md
+++ b/docs/en/troubleshooting/overview.md
@@ -1,7 +1,5 @@
 ---
 title: Troubleshooting
-order: 90000
-isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/en/troubleshooting/unable-to-start-bytebase-with-docker.md
+++ b/docs/en/troubleshooting/unable-to-start-bytebase-with-docker.md
@@ -1,6 +1,5 @@
 ---
 title: Unable to start Bytebase with Docker
-order: 90300
 ---
 
 # Unable to start Bytebase with Docker

--- a/docs/en/use-bytebase/backup-restore-database/backup.md
+++ b/docs/en/use-bytebase/backup-restore-database/backup.md
@@ -1,6 +1,5 @@
 ---
 title: Backup
-order: 40301
 ---
 
 # Backup

--- a/docs/en/use-bytebase/backup-restore-database/overview.md
+++ b/docs/en/use-bytebase/backup-restore-database/overview.md
@@ -1,6 +1,5 @@
 ---
 title: Backup and Restore Database
-order: 40300
 ---
 
 # Backup and Restore Database

--- a/docs/en/use-bytebase/backup-restore-database/restore-from-backup.md
+++ b/docs/en/use-bytebase/backup-restore-database/restore-from-backup.md
@@ -1,6 +1,5 @@
 ---
 title: Restore from Backup
-order: 40302
 ---
 
 # Restore from Backup

--- a/docs/en/use-bytebase/environment-policy/approval-policy.md
+++ b/docs/en/use-bytebase/environment-policy/approval-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Approval Policy
-order: 40401
 ---
 
 # Approval Policy

--- a/docs/en/use-bytebase/environment-policy/backup-schedule-policy.md
+++ b/docs/en/use-bytebase/environment-policy/backup-schedule-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Backup Schedule Policy
-order: 40402
 ---
 
 # Backup Schedule Policy

--- a/docs/en/use-bytebase/environment-policy/overview.md
+++ b/docs/en/use-bytebase/environment-policy/overview.md
@@ -1,6 +1,5 @@
 ---
 title: Environment Policy
-order: 40400
 ---
 
 # Environment Policy

--- a/docs/en/use-bytebase/overview.md
+++ b/docs/en/use-bytebase/overview.md
@@ -1,7 +1,5 @@
 ---
 title: 🧭 Use Bytebase
-order: 40000
-isHeader: true
 ---
 
 <!-- Do not show this page -->

--- a/docs/en/use-bytebase/sql-review-interface/create-the-sql-review-ticket.md
+++ b/docs/en/use-bytebase/sql-review-interface/create-the-sql-review-ticket.md
@@ -1,6 +1,5 @@
 ---
 title: Create the SQL review ticket
-order: 40101
 ---
 
 # Create the SQL review ticket

--- a/docs/en/use-bytebase/sql-review-interface/overview.md
+++ b/docs/en/use-bytebase/sql-review-interface/overview.md
@@ -1,6 +1,5 @@
 ---
 title: SQL Review Interface
-order: 40100
 ---
 
 # SQL Review Interface

--- a/docs/en/use-bytebase/vcs-integration/add-git-provider.md
+++ b/docs/en/use-bytebase/vcs-integration/add-git-provider.md
@@ -1,6 +1,5 @@
 ---
 title: Add Git Provider
-order: 40201
 ---
 
 # Add Git Provider

--- a/docs/en/use-bytebase/vcs-integration/create-the-first-baseline-migration.md
+++ b/docs/en/use-bytebase/vcs-integration/create-the-first-baseline-migration.md
@@ -1,6 +1,5 @@
 ---
 title: Create the First Baseline Migration
-order: 40204
 ---
 
 # Create the First Baseline Migration

--- a/docs/en/use-bytebase/vcs-integration/enable-version-control-workflow.md
+++ b/docs/en/use-bytebase/vcs-integration/enable-version-control-workflow.md
@@ -1,6 +1,5 @@
 ---
 title: Enable Version Control Workflow (GitOps) in Project
-order: 40202
 ---
 
 # Enable Version Control Workflow (GitOps) in Project

--- a/docs/en/use-bytebase/vcs-integration/name-and-organize-schema-files.md
+++ b/docs/en/use-bytebase/vcs-integration/name-and-organize-schema-files.md
@@ -1,6 +1,5 @@
 ---
 title: Name and Organize Schema Files
-order: 40203
 ---
 
 # Name and Organize Schema Files

--- a/docs/en/use-bytebase/vcs-integration/overview.md
+++ b/docs/en/use-bytebase/vcs-integration/overview.md
@@ -1,6 +1,5 @@
 ---
 title: VCS Integration (GitOps)
-order: 40200
 ---
 
 # VCS Integration (GitOps)

--- a/docs/en/use-bytebase/vcs-integration/troubleshoot.md
+++ b/docs/en/use-bytebase/vcs-integration/troubleshoot.md
@@ -1,6 +1,5 @@
 ---
 title: 🐞 Troubleshoot
-order: 40205
 ---
 
 # 🐞 Troubleshoot

--- a/docs/en/use-bytebase/webhook-integration/database-webhook.md
+++ b/docs/en/use-bytebase/webhook-integration/database-webhook.md
@@ -1,6 +1,5 @@
 ---
 title: Database Webhook
-order: 40502
 ---
 
 # Database Webhook

--- a/docs/en/use-bytebase/webhook-integration/overview.md
+++ b/docs/en/use-bytebase/webhook-integration/overview.md
@@ -1,6 +1,5 @@
 ---
 title: Webhook Integration
-order: 40500
 ---
 
 # Webhook Integration

--- a/docs/en/use-bytebase/webhook-integration/project-webhook.md
+++ b/docs/en/use-bytebase/webhook-integration/project-webhook.md
@@ -1,6 +1,5 @@
 ---
 title: Project Webhook
-order: 40501
 ---
 
 # Project Webhook
@@ -9,11 +8,11 @@ order: 40501
 
 ## Supported events
 
-* `Issue creation` - Post message when issue belonging to the configured project has been created.
-* `Issue status change` - Post message when the status of the issue belonging to the configured project has been changed.
-* `Issue task status change` - Post message when issue's enclosing task status has been changed.
-* `Issue info change` - Post message when issue's basic info such as assignee, title, description has been changed.
-* `Issue comment creation` - Post message when new comment added to the issue.
+- `Issue creation` - Post message when issue belonging to the configured project has been created.
+- `Issue status change` - Post message when the status of the issue belonging to the configured project has been changed.
+- `Issue task status change` - Post message when issue's enclosing task status has been changed.
+- `Issue info change` - Post message when issue's basic info such as assignee, title, description has been changed.
+- `Issue comment creation` - Post message when new comment added to the issue.
 
 ## Supported webhook endpoints
 
@@ -77,66 +76,69 @@ You need to implement the webhook server yourself, it doesn't work out of the bo
 
 - **Request Body**
 
-  | Key          | Type            | Description  |
-  | ------------ | ---------------- | ------------ |
-  | `level` | String | One of: <br/>&nbsp;&nbsp;`INFO`<br/>&nbsp;&nbsp;`SUCCESS`<br/>&nbsp;&nbsp;`WARN`<br/>&nbsp;&nbsp;`ERROR` |
-  | `activity_type` | String | One of: <br/>&nbsp;&nbsp;`bb.issue.create`<br/>&nbsp;&nbsp;`bb.issue.comment.create`<br/>&nbsp;&nbsp;`bb.issue.field.update`<br/>&nbsp;&nbsp;`bb.issue.status.update`<br/>&nbsp;&nbsp;`bb.pipeline.task.status.update`  |
-  | `title` | String | Webhook title |
-  | `description` | String | Webhook description |
-  | `link` | String | Webhook link |
-  | `creator_id` | Integer  | Updater id |
-  | `creator_name` | Integer  | Updater name |
-  | `created_ts` | Integer  | Webhook create timestamp |
-  | `issue` | Object  | Issue Object |
-  | `- id` | Integer  | Issue ID |
-  | `- name` | String  | Issue Name |
-  | `- status` | String  | Issue Status, one of: <br/>&nbsp;&nbsp;`OPEN`<br/>&nbsp;&nbsp;`DONE`<br/>&nbsp;&nbsp;`CANCELED`|
-  | `- type`   | String  | Issue Type, one of: <br/>&nbsp;&nbsp;`bb.issue.database.create`<br/>&nbsp;&nbsp;`bb.issue.database.schema.update`<br/>&nbsp;&nbsp;`bb.issue.database.schema.update.ghost`<br/>&nbsp;&nbsp;`bb.issue.database.data.update`| 
-  | `- description`| String | Issue Description|
-  | `project` | Object | Project Object |
-  | `- id`    | Integer | Project ID |
-  | `- name`  | String  | Project Name |
+  | Key             | Type    | Description                                                                                                                                                                                                               |
+  | --------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | `level`         | String  | One of: <br/>&nbsp;&nbsp;`INFO`<br/>&nbsp;&nbsp;`SUCCESS`<br/>&nbsp;&nbsp;`WARN`<br/>&nbsp;&nbsp;`ERROR`                                                                                                                  |
+  | `activity_type` | String  | One of: <br/>&nbsp;&nbsp;`bb.issue.create`<br/>&nbsp;&nbsp;`bb.issue.comment.create`<br/>&nbsp;&nbsp;`bb.issue.field.update`<br/>&nbsp;&nbsp;`bb.issue.status.update`<br/>&nbsp;&nbsp;`bb.pipeline.task.status.update`    |
+  | `title`         | String  | Webhook title                                                                                                                                                                                                             |
+  | `description`   | String  | Webhook description                                                                                                                                                                                                       |
+  | `link`          | String  | Webhook link                                                                                                                                                                                                              |
+  | `creator_id`    | Integer | Updater id                                                                                                                                                                                                                |
+  | `creator_name`  | Integer | Updater name                                                                                                                                                                                                              |
+  | `created_ts`    | Integer | Webhook create timestamp                                                                                                                                                                                                  |
+  | `issue`         | Object  | Issue Object                                                                                                                                                                                                              |
+  | `- id`          | Integer | Issue ID                                                                                                                                                                                                                  |
+  | `- name`        | String  | Issue Name                                                                                                                                                                                                                |
+  | `- status`      | String  | Issue Status, one of: <br/>&nbsp;&nbsp;`OPEN`<br/>&nbsp;&nbsp;`DONE`<br/>&nbsp;&nbsp;`CANCELED`                                                                                                                           |
+  | `- type`        | String  | Issue Type, one of: <br/>&nbsp;&nbsp;`bb.issue.database.create`<br/>&nbsp;&nbsp;`bb.issue.database.schema.update`<br/>&nbsp;&nbsp;`bb.issue.database.schema.update.ghost`<br/>&nbsp;&nbsp;`bb.issue.database.data.update` |
+  | `- description` | String  | Issue Description                                                                                                                                                                                                         |
+  | `project`       | Object  | Project Object                                                                                                                                                                                                            |
+  | `- id`          | Integer | Project ID                                                                                                                                                                                                                |
+  | `- name`        | String  | Project Name                                                                                                                                                                                                              |
 
 - **Response Body**
 
-  | Key          | Type            | Description  |
-  | ------------ | ---------------- | ------------ |
-  | `code` | String | Zero if success, non-zero if failed  |
-  | `message` | String |  Some error message   |
+  | Key       | Type   | Description                         |
+  | --------- | ------ | ----------------------------------- |
+  | `code`    | String | Zero if success, non-zero if failed |
+  | `message` | String | Some error message                  |
 
 - **Response StatusCode**
   - 200, OK
   - Other, if any error
 
 **Example Request Body**
+
 ```json
 {
-  "level": "INFO", 
-  "activity_type": "bb.issue.created", 
-  "title": "example webhook", 
+  "level": "INFO",
+  "activity_type": "bb.issue.created",
+  "title": "example webhook",
   "description": "example description",
   "link": "example link",
-  "creator_id": 1, 
-  "creator_name": "Bytebase", 
+  "creator_id": 1,
+  "creator_name": "Bytebase",
   "created_ts": 1651212107,
   "issue": {
-      "id": 1,
-      "name": "example issue",
-      "status": "OPEN",
-      "type": "bb.issue.database.create"
-    },
+    "id": 1,
+    "name": "example issue",
+    "status": "OPEN",
+    "type": "bb.issue.database.create"
+  },
   "project": {
-      "id": 1,
-      "name": "demo"
-    }
+    "id": 1,
+    "name": "demo"
+  }
 }
 ```
+
 **Example Response Body**
+
 - Success
   ```json
   {
-      "code": 0,
-      "message": ""
+    "code": 0,
+    "message": ""
   }
   ```
 - Failed

--- a/docs/en/what-is-bytebase.md
+++ b/docs/en/what-is-bytebase.md
@@ -1,7 +1,6 @@
 ---
 title: 👀 What is Bytebase
 description: Bytebase is a database schema change and version control management tool for teams. It consists of a web console and a backend. The backend has a migration core to manage database schema changes. It also integrates with VCS to enable version controlled schema management.
-order: 0
 ---
 
 # 👀 What is Bytebase

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -10,6 +10,7 @@ import {
 } from "./common/matrix";
 import { ALPHA_LIST } from "./common/glossary";
 import { getPosts } from "./api/posts";
+import { removeI18nPrefixPath } from "./common/utils";
 
 function glossaryRouteList() {
   const list = [];
@@ -60,6 +61,16 @@ function compareRouteList() {
   }
   return list;
 }
+
+const docsRouteList = async () => {
+  const { $content } = require("@nuxt/content");
+  const documentList = await $content("", { deep: true }).fetch();
+  const routeList = [];
+  for (const document of documentList) {
+    routeList.push(`/docs${removeI18nPrefixPath(document.path)}`);
+  }
+  return routeList;
+};
 
 function getI18nMessagesObject() {
   const localeDirRelativePath = "./locales";
@@ -149,6 +160,7 @@ export default {
       }
 
       return []
+        .concat(await docsRouteList())
         .concat(postRoutelist)
         .concat(glossaryRouteList())
         .concat(databaseFeatureRouteList())

--- a/pages/docs/_category/_document.vue
+++ b/pages/docs/_category/_document.vue
@@ -1,5 +1,5 @@
 <template>
-  <DocumentViewer :document="document" :prev="prev" :next="next" />
+  <DocumentViewer :document="document" />
 </template>
 
 <script>
@@ -9,10 +9,11 @@ export default {
   components: { DocumentViewer },
   layout: "content",
   async asyncData({ $content, params, app, redirect, error }) {
-    const path = `/${app.i18n.locale}/${params.category}/${params.document}`;
-    const document = await $content(path, {
-      deep: true,
-    })
+    const document = await $content(
+      app.i18n.locale,
+      params.category,
+      params.document
+    )
       .fetch()
       .catch(() => {
         error({ statusCode: 404, message: "Page not found" });
@@ -21,21 +22,9 @@ export default {
     if (!document) {
       redirect("/404");
     }
-    // The first level overview document isn't clickable, redirect it to /docs.
-    if (document.isHeader) {
-      redirect("/docs");
-    }
-
-    const [prev, next] = await $content("", { deep: true })
-      .where({ isHeader: { $ne: true } })
-      .sortBy("order")
-      .surround(path)
-      .fetch();
 
     return {
       document,
-      prev,
-      next,
     };
   },
 };

--- a/pages/docs/_category/_subcategory/_document.vue
+++ b/pages/docs/_category/_subcategory/_document.vue
@@ -1,5 +1,5 @@
 <template>
-  <DocumentViewer :document="document" :prev="prev" :next="next" />
+  <DocumentViewer :document="document" />
 </template>
 
 <script>
@@ -9,10 +9,12 @@ export default {
   components: { DocumentViewer },
   layout: "content",
   async asyncData({ $content, params, app, redirect, error }) {
-    const path = `/${app.i18n.locale}/${params.category}/${params.subcategory}/${params.document}`;
-    const document = await $content(path, {
-      deep: true,
-    })
+    const document = await $content(
+      app.i18n.locale,
+      params.category,
+      params.subcategory,
+      params.document
+    )
       .fetch()
       .catch(() => {
         error({ statusCode: 404, message: "Page not found" });
@@ -22,16 +24,8 @@ export default {
       redirect("/404");
     }
 
-    const [prev, next] = await $content("", { deep: true })
-      .where({ isHeader: { $ne: true } })
-      .sortBy("order")
-      .surround(path)
-      .fetch();
-
     return {
       document,
-      prev,
-      next,
     };
   },
 };

--- a/pages/docs/_slug.vue
+++ b/pages/docs/_slug.vue
@@ -1,5 +1,5 @@
 <template>
-  <DocumentViewer :document="document" :prev="prev" :next="next" />
+  <DocumentViewer :document="document" />
 </template>
 
 <script>
@@ -9,10 +9,7 @@ export default {
   components: { DocumentViewer },
   layout: "content",
   async asyncData({ $content, params, app, redirect, error }) {
-    const path = `/${app.i18n.locale}/${params.slug}`;
-    const document = await $content(path, {
-      deep: true,
-    })
+    const document = await $content(app.i18n.locale, params.slug)
       .fetch()
       .catch(() => {
         error({ statusCode: 404, message: "Page not found" });
@@ -22,16 +19,8 @@ export default {
       redirect("/404");
     }
 
-    const [prev, next] = await $content("", { deep: true })
-      .where({ isHeader: { $ne: true } })
-      .sortBy("order")
-      .surround(path)
-      .fetch();
-
     return {
       document,
-      prev,
-      next,
     };
   },
 };

--- a/types/docs.d.ts
+++ b/types/docs.d.ts
@@ -10,9 +10,7 @@ interface DocumentBodyNode {
 
 interface ContentDocument extends IContentDocument {
   body: DocumentBodyNode;
-  order: number;
   description?: string;
-  isHeader?: boolean;
 }
 
 interface Document extends ContentDocument {
@@ -20,8 +18,8 @@ interface Document extends ContentDocument {
 }
 
 interface DocumentTreeNode {
+  title: string;
   path: string;
-  document: Document;
   children: DocumentTreeNode[];
   displayChildren: boolean;
 }


### PR DESCRIPTION
Before, we must add a `order` metadata to sort docs. And it's hard to use when adding a new doc or change it. 

Now we can sort the docs easily with a file `docs/en/_layout.md`. And we can use it to add a separate menu item under the `/docs/cli` later.