### PR TITLE
chore: add `@nuxtjs/web-vitals` to enable vercel analytics

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -184,6 +184,7 @@ export default {
     "@nuxtjs/composition-api/module",
     "@pinia/nuxt",
     "@nuxtjs/google-analytics",
+    "@nuxtjs/web-vitals",
   ],
 
   // Modules: https://go.nuxtjs.dev/config-modules

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@nuxt/typescript-build": "^2.1.0",
     "@nuxtjs/google-analytics": "^2.4.0",
     "@nuxtjs/tailwindcss": "^4.2.0",
+    "@nuxtjs/web-vitals": "^0.1.8",
     "@types/dom-to-image": "^2.6.4",
     "@types/fs-extra": "^9.0.13",
     "@types/lodash": "^4.14.180",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ specifiers:
   '@nuxtjs/i18n': ^7.2.2
   '@nuxtjs/sitemap': ^2.4.0
   '@nuxtjs/tailwindcss': ^4.2.0
+  '@nuxtjs/web-vitals': ^0.1.8
   '@pinia/nuxt': ^0.1.8
   '@segment/analytics-next': ^1.34.0
   '@tailwindcss/aspect-ratio': ^0.4.0
@@ -78,6 +79,7 @@ devDependencies:
   '@nuxt/typescript-build': 2.1.0_btlhftwzzgzch3qgooej5zlxae
   '@nuxtjs/google-analytics': 2.4.0
   '@nuxtjs/tailwindcss': 4.2.1
+  '@nuxtjs/web-vitals': 0.1.8
   '@types/dom-to-image': 2.6.4
   '@types/fs-extra': 9.0.13
   '@types/lodash': 4.14.182
@@ -2190,6 +2192,14 @@ packages:
       - supports-color
       - ts-node
       - webpack
+    dev: true
+
+  /@nuxtjs/web-vitals/0.1.8:
+    resolution: {integrity: sha512-5oy0DCMV7a5xi5KwDx3I4/oGDNybPCMkjMVAFfY2sheikWQ6XAO3bOYKLyNnujoaRQJOW+2+N+PUznVbDE88nA==}
+    dependencies:
+      defu: 5.0.1
+      ufo: 0.7.11
+      web-vitals: 2.1.4
     dev: true
 
   /@nuxtjs/youch/4.2.3:
@@ -12501,6 +12511,10 @@ packages:
   /web-namespaces/1.1.4:
     resolution: {integrity: sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==}
     dev: false
+
+  /web-vitals/2.1.4:
+    resolution: {integrity: sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==}
+    dev: true
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}


### PR DESCRIPTION
As the vercel docs says that we don't need to add this plugin manually, but it's still in the ready status. Let's add it manually for testing.
https://vercel.com/docs/concepts/analytics#nuxt.js-(v2+)