### PR TITLE
chore: remove useless overview docs

### DIFF
--- a/common/const.ts
+++ b/common/const.ts
@@ -1,2 +1,0 @@
-// headerDocumentSuffix is the header document suffix and using to check is header.
-export const headerDocumentSuffix = "/overview";

--- a/docs/en/concepts/overview.md
+++ b/docs/en/concepts/overview.md
@@ -1,5 +1,0 @@
----
-title: 📚 Concepts
----
-
-<!-- Do not show this page -->

--- a/docs/en/features/overview.md
+++ b/docs/en/features/overview.md
@@ -1,5 +1,0 @@
----
-title: ✨ Features
----
-
-<!-- Do not show this page -->

--- a/docs/en/install/overview.md
+++ b/docs/en/install/overview.md
@@ -1,5 +1,0 @@
----
-title: 🚀 Install
----
-
-<!-- Do not show this page -->

--- a/docs/en/operating/overview.md
+++ b/docs/en/operating/overview.md
@@ -1,5 +1,0 @@
----
-title: 🔧 Operating
----
-
-<!-- Do not show this page -->

--- a/docs/en/reference/overview.md
+++ b/docs/en/reference/overview.md
@@ -1,5 +1,0 @@
----
-title: 📖 Reference
----
-
-<!-- Do not show this page -->

--- a/docs/en/settings/overview.md
+++ b/docs/en/settings/overview.md
@@ -1,5 +1,0 @@
----
-title: ⚙️ Settings
----
-
-<!-- Do not show this page -->

--- a/docs/en/troubleshooting/overview.md
+++ b/docs/en/troubleshooting/overview.md
@@ -1,5 +1,0 @@
----
-title: Troubleshooting
----
-
-<!-- Do not show this page -->

--- a/docs/en/use-bytebase/overview.md
+++ b/docs/en/use-bytebase/overview.md
@@ -1,5 +1,0 @@
----
-title: 🧭 Use Bytebase
----
-
-<!-- Do not show this page -->


### PR DESCRIPTION
We no longer need these empty `overview.md`.