### PR TITLE
chore: render markdown title manually

### DIFF
--- a/components/DocumentViewer.vue
+++ b/components/DocumentViewer.vue
@@ -6,7 +6,13 @@
     <div
       class="flex flex-col justify-start items-center w-full mx-auto lg:max-w-3xl 2xl:max-w-4xl"
     >
-      <nuxt-content class="w-full py-6 markdown-body" :document="document" />
+      <div class="w-full markdown-body nuxt-content pt-6">
+        <h1>{{ document.title }}</h1>
+      </div>
+      <nuxt-content
+        class="w-full pb-6 pt-4 markdown-body"
+        :document="document"
+      />
       <div
         class="w-full flex flex-col sm:flex-row sm:justify-start sm:items-center text-base"
       >

--- a/content/docs/en/cli/overview.md
+++ b/content/docs/en/cli/overview.md
@@ -1,11 +1,9 @@
 ---
-title: Introducing Bytebase CLI bb
+title: Introducing Bytebase CLI
 description: This page contains a getting-started covering frequently used commands, followed by a list of all options and commands.
 ---
 
-# Introducing Bytebase CLI `bb`
-
-bb CLI is the command-line tool of Bytebase, helping developers integrate MySQL and PostgreSQL schema change into the existing CI/CD workflow. By integrating bb with your existing CI/CD system (GitLab CI, GitHub Actions, etc.), you can bring all best practices of CI/CD to the database.
+`bb` CLI is the command-line tool of Bytebase, helping developers integrate MySQL and PostgreSQL schema change into the existing CI/CD workflow. By integrating bb with your existing CI/CD system (GitLab CI, GitHub Actions, etc.), you can bring all best practices of CI/CD to the database.
 
 This page contains a getting-started covering frequently used commands, followed by a list of all options and commands.
 

--- a/content/docs/en/concepts/data-model.md
+++ b/content/docs/en/concepts/data-model.md
@@ -2,8 +2,6 @@
 title: Data Model
 ---
 
-# Data Model
-
 ![Bytebase data model](/static/docs-assets/data-model_v1.png)
 
 ## Workspace

--- a/content/docs/en/concepts/migration-types.md
+++ b/content/docs/en/concepts/migration-types.md
@@ -2,8 +2,6 @@
 title: Migration Types
 ---
 
-# Migration Types
-
 <hint-block type="info">
 
 Migration type is only applicable to project using <a href="/docs/features/version-control">Version Control Workflow</a>.

--- a/content/docs/en/concepts/roles-and-permissions.md
+++ b/content/docs/en/concepts/roles-and-permissions.md
@@ -2,8 +2,6 @@
 title: Roles and Permissions
 ---
 
-# Roles and Permissions
-
 Bytebase has two disjoint set of roles:
 
 1. Workspace roles: `Owner`, `DBA`, `Developer`

--- a/content/docs/en/concepts/schema-change-workflow.md
+++ b/content/docs/en/concepts/schema-change-workflow.md
@@ -2,8 +2,6 @@
 title: Schema Change Workflow
 ---
 
-# Schema Change Workflow
-
 There are 2 typical workflows employed by the team to deal with database schema changes. [UI workflow](#ui-workflow) and [version control workflow (GitOps)](#gitops-workflow).
 
 ## UI workflow

--- a/content/docs/en/concepts/tenant-database.md
+++ b/content/docs/en/concepts/tenant-database.md
@@ -2,15 +2,12 @@
 title: Tenant Database
 ---
 
-# Tenant Database
-
 Tenant database describes a collection of databases with identical database schema. Each individual database corresponds to a tenant. Typical scenarios:
 
-* A team may provide a Software as a Service (SaaS) application. It provides a separate instance for each of its customers/tenants, and each tenant has its own database.
-* A team may provide multi-region deployments, and each region is a separate instance having its own database.
+- A team may provide a Software as a Service (SaaS) application. It provides a separate instance for each of its customers/tenants, and each tenant has its own database.
+- A team may provide multi-region deployments, and each region is a separate instance having its own database.
 
 A tenant can be a SaaS application customer, a region, a game server name and etc. Whenever application wants to make schema changes, it needs to apply the change to all databases across all tenants.
-
 
 Bytebase can manage the database schema lifecycle for Tenant database. Below shows how Bytebase progresses a schema change for a game company across all its game servers.
 

--- a/content/docs/en/document-write-guide.md
+++ b/content/docs/en/document-write-guide.md
@@ -3,8 +3,6 @@ title: ✍️ Document write guide
 description: This section shows the steps of writing a document.
 ---
 
-# ✍️ Document write guide
-
 This section shows the steps of writing a document.
 
 ## The structure of a `.md` file

--- a/content/docs/en/error-code.md
+++ b/content/docs/en/error-code.md
@@ -2,8 +2,6 @@
 title: Error Code
 ---
 
-# Error Code
-
 ## General
 
 ### 0 - OK

--- a/content/docs/en/faq.md
+++ b/content/docs/en/faq.md
@@ -2,8 +2,6 @@
 title: FAQ
 ---
 
-# FAQ
-
 ## How to reach us?
 
 Bytebase is open sourced on [GitHub](https://github.com/bytebase/bytebase/)

--- a/content/docs/en/features/anomaly-center.md
+++ b/content/docs/en/features/anomaly-center.md
@@ -2,8 +2,6 @@
 title: Anomaly Center
 ---
 
-# Anomaly Center
-
 Bytebase periodically scans all managed instances and databases to catch potential anomalies such as [schema drift detection](/docs/features/drift-detection), [backup missing](/docs/features/backup-and-restore#detect-missing-backup). **Anomaly Center** is the place to provide user a holistic view to view those anomalies.
 
 ![anomaly-center](/static/docs-assets/anomaly-center.png)

--- a/content/docs/en/features/archive.md
+++ b/content/docs/en/features/archive.md
@@ -2,8 +2,6 @@
 title: Archive
 ---
 
-# Archive
-
 Bytebase disallows to delete the project/instance/environment resource permanently, this is both a precaution to prevent any unexpected data loss and also a feature to keep every action traceable.
 
 Meanwhile, Bytebase offers an archiving feature. Archived resources won't appear in the normal interface and can only be found from the **Archive Dashboard.** Archived resources can still be restored any time.

--- a/content/docs/en/features/backup-and-restore.md
+++ b/content/docs/en/features/backup-and-restore.md
@@ -2,8 +2,6 @@
 title: Backup and Restore
 ---
 
-# Backup and Restore
-
 Bytebase supports both automatic and manual backup at the database level. User can also restore the backup to a different database.
 
 When Bytebase restores the backup to a new database, it also records the original parent database as well as a branch migration history linking with the restoring process.

--- a/content/docs/en/features/drift-detection.md
+++ b/content/docs/en/features/drift-detection.md
@@ -2,8 +2,6 @@
 title: Drift Detection
 ---
 
-# Drift Detection
-
 Bytebase is supposed to take over applying the database schema changes on behalf of the user. It records the detailed migration history and the before/after schema snapshot for each migration it applies.
 
 A background process periodically compares the recorded latest schema with the actual schema in the targeting database and surface the drift if found. Drift usually happens when user applies out-of-band schema changes (such as hot fix) directly to the database without using Bytebase.

--- a/content/docs/en/features/migration-history.md
+++ b/content/docs/en/features/migration-history.md
@@ -2,8 +2,6 @@
 title: Migration History
 ---
 
-# Migration History
-
 Bytebase records the detailed migration history and the before/after schema snapshot for each migration it applies. It also leverages these records to [detect schema drifts](/docs/features/drift-detection).
 
 ![schema-migration-bytebase](/static/docs-assets/schema-migration-bytebase.png)

--- a/content/docs/en/features/sql-advisor/backward-compatibility-migration-check.md
+++ b/content/docs/en/features/sql-advisor/backward-compatibility-migration-check.md
@@ -2,8 +2,6 @@
 title: Backward Compatibility Migration Check
 ---
 
-# Backward Compatibility Migration Check
-
 Introducing backward incompatible schema changes is one of the most common mistakes made by developers. And enforcing backward compatible schema change is the standard practice adopted by many engineering organizations. Bytebase provides the built-in backward compatible check to catch all common incompatible schema change [scenarios](https://www.bytebase.com/doc/error#backward-incompatible-migration).
 
 ![sql-advisor](/static/docs-assets/sql-advisor.png)

--- a/content/docs/en/features/sql-advisor/overview.md
+++ b/content/docs/en/features/sql-advisor/overview.md
@@ -2,8 +2,6 @@
 title: SQL Advisor
 ---
 
-# SQL Advisor
-
 Bytebase provides automatic SQL lint to check common issues in schema change process.
 
 ![sql-advisor](/static/docs-assets/sql-advisor.png)

--- a/content/docs/en/features/sql-editor/explore-the-schema.md
+++ b/content/docs/en/features/sql-editor/explore-the-schema.md
@@ -2,8 +2,6 @@
 title: Explore the Schema
 ---
 
-# Explore the Schema
-
 SQL Editor displays the database connections in a tree view. This allows users to navigate between different databases to explore the schema.
 
 ## Databases

--- a/content/docs/en/features/sql-editor/never-miss-your-works.md
+++ b/content/docs/en/features/sql-editor/never-miss-your-works.md
@@ -2,8 +2,6 @@
 title: Saved Sheet and Query History
 ---
 
-# Saved Sheet and Query History
-
 ## How to save the sheet
 
 Click the `Save` button on the upper right of the Editor or use the shortcut key `(⌘ + S)` to save your SQL queries for later reference. You can find them in the `Sheets` panel on the left.

--- a/content/docs/en/features/sql-editor/overview.md
+++ b/content/docs/en/features/sql-editor/overview.md
@@ -2,8 +2,6 @@
 title: SQL Editor
 ---
 
-# SQL Editor
-
 Your All-in-one SQL Editor, easy-to-use query interface to SELECT database records.
 
 > Inspect records, explore schema, sharing SQL scripts, and more.

--- a/content/docs/en/features/sql-editor/query-results.md
+++ b/content/docs/en/features/sql-editor/query-results.md
@@ -2,8 +2,6 @@
 title: Query Results
 ---
 
-# Query Results
-
 You can easily check the results by running your SQL queries.
 
 ## Search Result

--- a/content/docs/en/features/sql-editor/run-queries.md
+++ b/content/docs/en/features/sql-editor/run-queries.md
@@ -2,8 +2,6 @@
 title: Run and EXPLAIN Query
 ---
 
-# Run and EXPLAIN Query
-
 <hint-block type="info">
 
 Please note that SQL Editor only supports running SELECT queries now. SQL will detect your SQL queries. If you are running DDL or DML change queries, it will prompt you to create a new issue to start the SQL review process.

--- a/content/docs/en/features/sql-editor/share-sheet-with-teammates.md
+++ b/content/docs/en/features/sql-editor/share-sheet-with-teammates.md
@@ -2,8 +2,6 @@
 title: Share Sheet with Teammates
 ---
 
-# Share Sheet with Teammates
-
 Click the `Share` button on the upper right of the Editor to share SQL queries in the current tab with your teammates.
 
 ## Configure sheet access

--- a/content/docs/en/features/sql-editor/writing-a-query.md
+++ b/content/docs/en/features/sql-editor/writing-a-query.md
@@ -2,8 +2,6 @@
 title: Compose a Query
 ---
 
-# Compose a Query
-
 SQL Editor supports auto-completion, code formatting, and keyboard shortcuts.
 
 ## Auto-completion

--- a/content/docs/en/features/sql-review.md
+++ b/content/docs/en/features/sql-review.md
@@ -2,8 +2,6 @@
 title: SQL Review
 ---
 
-# SQL Review
-
 SQL Review is the classic and widely used process for developers and DBAs to coordinate database schema changes.
 
 Developers first submit their SQL statement for DBA to review. After review is approved, the SQL statement will then be applied to the corresponding database. For a single change, this step would normally be repeated for each environment (e.g. integration, staging, prod).

--- a/content/docs/en/features/tenant-database-management.md
+++ b/content/docs/en/features/tenant-database-management.md
@@ -2,8 +2,6 @@
 title: Tenant Database Management
 ---
 
-# Tenant Database Management
-
 Tenant Database Management allows database administrators to manage **a collection of databases with identical schemas**.
 
 For example, a software company offers medical record storage services for its customers, hospitals. Each hospital is considered as a tenant, and each tenant has to store their patient data in its own database for regulation or privacy purposes. This feature allows updating database schema for all tenants in a simple and consistent way. Other use cases include multi-location databases for supporting highly-available services where each location is a tenant.

--- a/content/docs/en/features/version-control.md
+++ b/content/docs/en/features/version-control.md
@@ -2,8 +2,6 @@
 title: Version Control (GitOps)
 ---
 
-# Version Control (GitOps)
-
 "**Version controlled schema**" aka "**Database-as-code**" is a practice to store the database schema in a version control system (VCS) just like how application code is stored. The database schema consists of a bunch of database migration scripts. These scripts usually follow a naming convention to identify the order of their relative execution sequence. After executing all the migration scripts, it will produce an exact copy of the database schema to the corresponding live database. In this model, the migration scripts are the source of truth of the database schema. You can check the reference for a detailed writeup on this topic.
 
 Bytebase supports this version control model to integrate database schema with the VCS. To set it up, please follow

--- a/content/docs/en/features/webhook.md
+++ b/content/docs/en/features/webhook.md
@@ -2,8 +2,6 @@
 title: Webhook
 ---
 
-# Webhook
-
 ## Project Webhook
 
 User can configure project-level webhooks to let Bytebase post messages to the configured webhook endpoint upon various events.

--- a/content/docs/en/install/build-from-source.md
+++ b/content/docs/en/install/build-from-source.md
@@ -2,8 +2,6 @@
 title: Build from Source
 ---
 
-# Build from Source
-
 ## Prerequisite
 
 1. Install [pnpm](https://pnpm.io/installation), Bytebase requires Node.js >=17.0.

--- a/content/docs/en/install/external-postgres.md
+++ b/content/docs/en/install/external-postgres.md
@@ -2,8 +2,6 @@
 title: Use External PostgreSQL Database
 ---
 
-# Use External PostgreSQL Database
-
 By default, Bytebase bundles an embedded PostgreSQL instance for storing its own metadata. Alternatively, you can supply [--pg](/docs/reference/command-line#--pg-string) to store these metadata in an external PostgreSQL database.
 
 ## Prerequisites

--- a/content/docs/en/install/install-with-docker.md
+++ b/content/docs/en/install/install-with-docker.md
@@ -2,8 +2,6 @@
 title: Docker (5 seconds)
 ---
 
-# Docker (5 seconds)
-
 **Latest release version:** [**1.0.5**](https://github.com/bytebase/bytebase/releases/tag/1.0.5)
 
 <hint-block type="info">

--- a/content/docs/en/operating/disaster-recovery.md
+++ b/content/docs/en/operating/disaster-recovery.md
@@ -2,8 +2,6 @@
 title: Disaster Recovery
 ---
 
-# Disaster Recovery
-
 ## **Periodically snapshot the entire** [**--data**](/docs/reference/command-line#data-less-than-less-than-directory-greater-than-greater-than) **directory**
 
 Bytebase stores its own data into a [SQLite](http://sqlite.com) file called `bytebase.db`under the [--data](/docs/reference/command-line#data-less-than-less-than-directory-greater-than-greater-than) directory. Besides the main data file, SQLite also creates 2 additional files: `bytebase.db-shm` for managing share memory and `bytebase.db-wal` for write ahead logging.

--- a/content/docs/en/operating/production-setup.md
+++ b/content/docs/en/operating/production-setup.md
@@ -2,8 +2,6 @@
 title: Production Setup
 ---
 
-# Production Setup
-
 ### 1. Make sure [--host](/docs/reference/command-line#host-less-than-less-than-string-greater-than-greater-than), [--port](/docs/reference/command-line#port-less-than-less-than-number-greater-than-greater-than) match exactly to the host:port address where Bytebase supposed to be visited.
 
 Bytebase uses --host, --port to configure the VCS webhook callback used by the [project version control workflow](/docs/use-bytebase/vcs-integration/enable-version-control-workflow#step-3-configure-deploy). If host:port mismatches, then committed migration scripts will not trigger the issue creation in Bytebase.

--- a/content/docs/en/operating/telemetry.md
+++ b/content/docs/en/operating/telemetry.md
@@ -2,6 +2,4 @@
 title: Telemetry
 ---
 
-# Telemetry
-
 Bytebase currently does NOT collect any telemetry data from the self-hosted instance.

--- a/content/docs/en/reference/command-line.md
+++ b/content/docs/en/reference/command-line.md
@@ -2,8 +2,6 @@
 title: Server Startup Options
 ---
 
-# Server Startup Options
-
 The "help" command prints all applicable options
 
 ```bash

--- a/content/docs/en/settings/customize-workspace.md
+++ b/content/docs/en/settings/customize-workspace.md
@@ -2,8 +2,6 @@
 title: Customize your workspace with your own logo
 ---
 
-# Customize your workspace with your own logo
-
 For Team and Enterprise plans, you can customize your workspace with your own logo. To add logo to your workspace,
 
 1. Click `Settings` on the navigation bar.

--- a/content/docs/en/settings/external-sql-console.md
+++ b/content/docs/en/settings/external-sql-console.md
@@ -2,8 +2,6 @@
 title: Link External SQL Console
 ---
 
-# Link External SQL Console
-
 > If your team use a separate SQL console such as phpMyAdmin, you can provide its URL pattern, so that Bytebase can surface the console link on the relevant database and table UI.
 
 Go to `Settings` , under `Workspace`, click `General`. Here you can configure the SQL console URL

--- a/content/docs/en/troubleshooting/how-to-perform-upgrade.md
+++ b/content/docs/en/troubleshooting/how-to-perform-upgrade.md
@@ -2,8 +2,6 @@
 title: How to perform upgrade
 ---
 
-# How to perform upgrade
-
 ## Background
 
 Bytebase stores its own metadata in a [Postgres](https://www.postgresql.org/) database. As we add new features, we may also perform database schema changes (i.e. database migrations).

--- a/content/docs/en/troubleshooting/how-to-solve-oauth-cors-error-with-old-gitlab-version.md
+++ b/content/docs/en/troubleshooting/how-to-solve-oauth-cors-error-with-old-gitlab-version.md
@@ -2,8 +2,6 @@
 title: How to solve OAuth CORS error with old GitLab version
 ---
 
-# How to solve OAuth CORS error with old GitLab version
-
 When using old GitLab version (e.g. 9.4.0) to setup VCS integration, you may encounter OAuth error https://github.com/bytebase/bytebase/issues/467:
 
 <p><img width="500" alt="image" src="https://user-images.githubusercontent.com/24653555/154427178-5c3b0d15-6ef3-4e65-8b62-02812a9e7b27.png"></p>

--- a/content/docs/en/troubleshooting/unable-to-start-bytebase-with-docker.md
+++ b/content/docs/en/troubleshooting/unable-to-start-bytebase-with-docker.md
@@ -2,8 +2,6 @@
 title: Unable to start Bytebase with Docker
 ---
 
-# Unable to start Bytebase with Docker
-
 ## Using [Colima](https://github.com/abiosoft/colima)
 
 Due to the vm mechanism of colima, try to use the `--mount` option when starting colima as shown below:

--- a/content/docs/en/use-bytebase/backup-restore-database/backup.md
+++ b/content/docs/en/use-bytebase/backup-restore-database/backup.md
@@ -2,8 +2,6 @@
 title: Backup
 ---
 
-# Backup
-
 ![backup-example](/static/docs-assets/backup-example.png)
 
 ## Automatic weekly backup

--- a/content/docs/en/use-bytebase/backup-restore-database/overview.md
+++ b/content/docs/en/use-bytebase/backup-restore-database/overview.md
@@ -2,8 +2,6 @@
 title: Backup and Restore Database
 ---
 
-# Backup and Restore Database
-
 Bytebase supports both automatic and manual backup at the database level. User can also restore the backup to a different database.
 
 User accesses the database backup feature by visiting the "Backups" tab from the database page.

--- a/content/docs/en/use-bytebase/backup-restore-database/restore-from-backup.md
+++ b/content/docs/en/use-bytebase/backup-restore-database/restore-from-backup.md
@@ -2,8 +2,6 @@
 title: Restore from Backup
 ---
 
-# Restore from Backup
-
 <hint-block type="warning">
 
 Bytebase only allows to restore backup to a new database under the same project and environment.

--- a/content/docs/en/use-bytebase/environment-policy/approval-policy.md
+++ b/content/docs/en/use-bytebase/environment-policy/approval-policy.md
@@ -2,8 +2,6 @@
 title: Approval Policy
 ---
 
-# Approval Policy
-
 ## Updating schema on existing database
 
 `Owner` or `DBA` can configure the approval policy for a particular environment from the "Environment" detail page:

--- a/content/docs/en/use-bytebase/environment-policy/backup-schedule-policy.md
+++ b/content/docs/en/use-bytebase/environment-policy/backup-schedule-policy.md
@@ -2,8 +2,6 @@
 title: Backup Schedule Policy
 ---
 
-# Backup Schedule Policy
-
 <hint-block type="info">
 
 The backup enforcement is **NOT retroactive**, which means the updated policy **won't** automatically alter the existing database backup setting, it will only enforce the future setup. On the other hand, Bytebase will report the discrepancy if the current setting does not conform to the active policy , which gives user the control to switch the existing setting at the appropriate time.

--- a/content/docs/en/use-bytebase/environment-policy/overview.md
+++ b/content/docs/en/use-bytebase/environment-policy/overview.md
@@ -2,8 +2,6 @@
 title: Environment Policy
 ---
 
-# Environment Policy
-
 <hint-block type="info">
 
 Only **Owner** or **DBA** can configure environment policies.

--- a/content/docs/en/use-bytebase/sql-review-interface/create-the-sql-review-ticket.md
+++ b/content/docs/en/use-bytebase/sql-review-interface/create-the-sql-review-ticket.md
@@ -2,8 +2,6 @@
 title: Create the SQL review ticket
 ---
 
-# Create the SQL review ticket
-
 For project using the [UI-based schema change workflow](/docs/concepts/schema-change-workflow#ui-workflow), developer normally would go to the project detail page and click the "Alter Schema" button from the quick action bar. From there developer can choose one or more databases to apply the schema change.
 
 ![Change a single database schema](/static/docs-assets/alter-schema-single-db.png)

--- a/content/docs/en/use-bytebase/sql-review-interface/overview.md
+++ b/content/docs/en/use-bytebase/sql-review-interface/overview.md
@@ -2,8 +2,6 @@
 title: SQL Review Interface
 ---
 
-# SQL Review Interface
-
 Bytebase provides a comprehensive SQL review interface for Developer and DBA to collaborate on database tasks and track their progress.
 
 ![issue-view-dashboard](/static/docs-assets/issue-view-dashboard.png)

--- a/content/docs/en/use-bytebase/vcs-integration/add-git-provider.md
+++ b/content/docs/en/use-bytebase/vcs-integration/add-git-provider.md
@@ -2,8 +2,6 @@
 title: Add Git Provider
 ---
 
-# Add Git Provider
-
 > Due to the complexity and details involved, this guide takes a bit patience to follow. If you have suggestions to improve the guide or/and the setup workflow, please tell us at support@bytebase.com
 
 Estimate setup time: 30 minutes. This is a [reference setup](https://demo.bytebase.com/setting/version-control/bytebasegitlabcom-16001) showing what it will look like after the setup.

--- a/content/docs/en/use-bytebase/vcs-integration/create-the-first-baseline-migration.md
+++ b/content/docs/en/use-bytebase/vcs-integration/create-the-first-baseline-migration.md
@@ -2,8 +2,6 @@
 title: Create the First Baseline Migration
 ---
 
-# Create the First Baseline Migration
-
 To bootstrap the VCS integration, Bytebase needs to know the current schema of the corresponding live database. This is achieved by using a baseline migration script which includes the entire schema of that live database.
 
 To create a baseline migration, use `baseline` as the migration type in the configured [file path template](/docs/use-bytebase/vcs-integration/name-and-organize-schema-files#file-path-template).

--- a/content/docs/en/use-bytebase/vcs-integration/enable-version-control-workflow.md
+++ b/content/docs/en/use-bytebase/vcs-integration/enable-version-control-workflow.md
@@ -2,8 +2,6 @@
 title: Enable Version Control Workflow (GitOps) in Project
 ---
 
-# Enable Version Control Workflow (GitOps) in Project
-
 > To enable version control workflow, project owner needs to link one of their Git repositories with their Bytebase project.
 
 Estimate setup time: 15 minutes. This is a [reference setup](https://demo.bytebase.com/project/blog-git-3003#version-control) showing what it will look like after the setup.

--- a/content/docs/en/use-bytebase/vcs-integration/name-and-organize-schema-files.md
+++ b/content/docs/en/use-bytebase/vcs-integration/name-and-organize-schema-files.md
@@ -2,8 +2,6 @@
 title: Name and Organize Schema Files
 ---
 
-# Name and Organize Schema Files
-
 If project enables version control workflow, it will observe file changes in the observed repository. But after Bytebase notices a particular file change, it still needs to figure out the exact database where the change should apply. Also there are different migration types and Bytebase needs to figure out which. To achieve those tasks, Bytebase requires the file to follow a naming convention.
 
 ## File Path Template

--- a/content/docs/en/use-bytebase/vcs-integration/overview.md
+++ b/content/docs/en/use-bytebase/vcs-integration/overview.md
@@ -2,8 +2,6 @@
 title: VCS Integration (GitOps)
 ---
 
-# VCS Integration (GitOps)
-
 The VCS Integration is a 4-step setup. You can check this [demo issue](https://demo.bytebase.com/issue/add-createdat-column-to-userpostcomment-table-for-dev-environment-13008) created by observing the [code commit](https://gitlab.bytebase.com/bytebase-demo/blog/-/commit/171ceaf7659ceb8e495aa3ef356ec686656f9dc0) to see what it looks like after the setup.
 
 ### [Step 1 - Add Git Provider](/docs/use-bytebase/vcs-integration/add-git-provider)

--- a/content/docs/en/use-bytebase/vcs-integration/troubleshoot.md
+++ b/content/docs/en/use-bytebase/vcs-integration/troubleshoot.md
@@ -2,8 +2,6 @@
 title: 🐞 Troubleshoot
 ---
 
-# 🐞 Troubleshoot
-
 ### Committed migration file does not trigger issue creation
 
 1. Check the committed file conforms to the [naming convention](/docs/use-bytebase/vcs-integration/name-and-organize-schema-files) and directory structure conforms to the [layout](/docs/use-bytebase/vcs-integration/name-and-organize-schema-files#file-organization).

--- a/content/docs/en/use-bytebase/webhook-integration/database-webhook.md
+++ b/content/docs/en/use-bytebase/webhook-integration/database-webhook.md
@@ -2,8 +2,6 @@
 title: Database Webhook
 ---
 
-# Database Webhook
-
 ![database-webhook](/static/docs-assets/database-webhook.png)
 
 User can set webhook URLs for databases. After a successful backup, an HTTP POST request will be sent to it.

--- a/content/docs/en/use-bytebase/webhook-integration/overview.md
+++ b/content/docs/en/use-bytebase/webhook-integration/overview.md
@@ -2,8 +2,6 @@
 title: Webhook Integration
 ---
 
-# Webhook Integration
-
 > User can configure webhook in the project to enable Bytebase to post messages to the configured webhook endpoint upon various events.
 
 ### [Project webhook](/docs/use-bytebase/webhook-integration/project-webhook)

--- a/content/docs/en/use-bytebase/webhook-integration/project-webhook.md
+++ b/content/docs/en/use-bytebase/webhook-integration/project-webhook.md
@@ -2,8 +2,6 @@
 title: Project Webhook
 ---
 
-# Project Webhook
-
 ![project-webhook-configure](/static/docs-assets/project-webhook-configure.png)
 
 ## Supported events

--- a/content/docs/en/what-is-bytebase.md
+++ b/content/docs/en/what-is-bytebase.md
@@ -3,8 +3,6 @@ title: 👀 What is Bytebase
 description: Bytebase is a database schema change and version control management tool for teams. It consists of a web console and a backend. The backend has a migration core to manage database schema changes. It also integrates with VCS to enable version controlled schema management.
 ---
 
-# 👀 What is Bytebase
-
 ## 👋🏼 Introduction
 
 ![Home dashboard](/static/docs-assets/overview.png)

--- a/layouts/content.vue
+++ b/layouts/content.vue
@@ -41,7 +41,7 @@
         >
       </nav>
       <div
-        class="w-8 sm:w-64 h-8 pl-0 sm:px-3 border rounded-2xl flex flex-row justify-center sm:justify-between items-center opacity-80 cursor-pointer hover:opacity-100"
+        class="w-9 sm:w-64 h-9 pl-0 sm:px-3 border rounded-3xl flex flex-row justify-center sm:justify-between items-center opacity-80 cursor-pointer hover:opacity-100"
         @click="handleSearchBtnClick"
       >
         <div class="flex flex-row justify-start items-center">


### PR DESCRIPTION
Render markdown title manually to unify `changelog/blog` and `docs` display.