### PR TITLE
docs: add back the missing emoji for intro and expand get started by default

### DIFF
--- a/content/docs/en/_layout.md
+++ b/content/docs/en/_layout.md
@@ -1,11 +1,11 @@
 ---
 # expand_section_list is the list of default expanded sections.
-expand_section_list: ["Introduction", "👉 Get Started with Bytebase"]
+expand_section_list: ["👀 Introduction", "🐣 Get Started"]
 ---
 
 # docs_layout
 
-## Introduction
+## 👀 Introduction
 
 ### [What is Bytebase](/introduction/what-is-bytebase)
 


### PR DESCRIPTION
the emoji for intro seems missing