### PR TITLE
feat: improve blog and changelog's rendering mechanism

### DIFF
--- a/components/DocumentViewer.vue
+++ b/components/DocumentViewer.vue
@@ -57,7 +57,7 @@
     <div
       class="hidden fixed right-0 top-32 pt-12 w-60 py-2 h-auto max-h-screen flex-shrink-0 lg:flex flex-col justify-start items-start overflow-y-auto text-sm"
     >
-      <Toc :content="document" :scroll-offset="20" break-point="md" />
+      <Toc :content="document" :scroll-offset="20" class="md:flex" />
     </div>
 
     <!-- Subscribtion popup -->

--- a/components/DocumentViewer.vue
+++ b/components/DocumentViewer.vue
@@ -5,6 +5,7 @@
     class="flex flex-col justify-start items-start px-4 lg:pr-64 w-full h-auto relative overflow-x-hidden overflow-y-auto"
   >
     <div
+      id="content"
       class="flex flex-col justify-start items-center w-full mx-auto lg:max-w-3xl 2xl:max-w-4xl"
     >
       <div class="w-full markdown-body nuxt-content pt-6">
@@ -56,7 +57,7 @@
     <div
       class="hidden fixed right-0 top-32 pt-12 w-60 py-2 h-auto max-h-screen flex-shrink-0 lg:flex flex-col justify-start items-start overflow-y-auto text-sm"
     >
-      <Toc :content="document" />
+      <Toc :content="document" :scroll-offset="20" break-point="md" />
     </div>
 
     <!-- Subscribtion popup -->

--- a/components/DocumentViewer.vue
+++ b/components/DocumentViewer.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    id="content-container"
     ref="ducumentContainerRef"
     class="flex flex-col justify-start items-start px-4 lg:pr-64 w-full h-auto relative overflow-x-hidden overflow-y-auto"
   >
@@ -53,24 +54,9 @@
 
     <!-- TOC -->
     <div
-      v-show="toc.length !== 0"
-      class="hidden fixed right-0 top-32 pt-12 w-60 py-2 pr-4 h-auto max-h-screen flex-shrink-0 lg:flex flex-col justify-start items-start overflow-y-auto text-sm"
+      class="hidden fixed right-0 top-32 pt-12 w-60 py-2 h-auto max-h-screen flex-shrink-0 lg:flex flex-col justify-start items-start overflow-y-auto text-sm"
     >
-      <span class="text-black pb-2 pl-4 border-l border-gray-200"
-        >Table of Contents</span
-      >
-      <a
-        v-for="item of toc"
-        :key="item.id"
-        class="leading-7 text-gray-500 flex-shrink-0 w-full truncate whitespace-nowrap border-l border-gray-200 pl-4 hover:text-accent"
-        :class="`pl-${(item.depth - 1) * 4} ${
-          state.currentHashId === item.id ? 'text-accent border-accent' : ''
-        }`"
-        :href="`#${item.id}`"
-        @click="state.currentHashId = item.id"
-      >
-        {{ item.text }}
-      </a>
+      <Toc :content="document" />
     </div>
 
     <!-- Subscribtion popup -->
@@ -95,7 +81,6 @@
 
 <script lang="ts">
 import {
-  computed,
   defineComponent,
   onMounted,
   reactive,
@@ -111,41 +96,24 @@ import { ContentDocument } from "~/types/docs";
 import storage from "~/common/storage";
 import { validDocsCategoryList } from "~/common/const";
 import SubscribeSection from "./SubscribeSection.vue";
+import Toc from "./Toc.vue";
+
 dayjs.extend(relativeTime);
 
-// Table of Content Object
-interface TOC {
-  id: string;
-  depth: number;
-  text: string;
-}
-
-interface State {
-  currentHashId: string;
-  showSubscribtionPopup: boolean;
-}
-
 export default defineComponent({
-  components: { SubscribeSection },
+  components: { SubscribeSection, Toc },
   props: {
     document: Object,
   },
   setup(props) {
     const { $content, route } = useContext();
     const meta = useMeta({});
-    const state = reactive<State>({
-      currentHashId: "",
+    const state = reactive({
       showSubscribtionPopup: false,
     });
     const ducumentContainerRef = ref<HTMLDivElement>();
     const prev = ref<any>(undefined);
     const next = ref<any>(undefined);
-    const toc = computed(() => {
-      // Only show h2,h3 in toc.
-      return (props.document?.toc as TOC[]).filter(
-        (t) => t.depth >= 2 && t.depth <= 3
-      );
-    });
     const githubFilePath = `/content${props.document?.path}${props.document?.extension}`;
 
     useFetch(async () => {
@@ -209,46 +177,6 @@ export default defineComponent({
         },
       ];
 
-      // Add hash link for each TOC node.
-      const hashTagNodeList =
-        ducumentContainerRef.value?.querySelectorAll("h2,h3");
-      if (hashTagNodeList && hashTagNodeList.length > 0) {
-        const tagElementList = Array.from(hashTagNodeList) as HTMLElement[];
-        const hash = window.location.hash;
-        if (hash !== "#") {
-          for (const item of tagElementList) {
-            if (hash === `#${item.id}`) {
-              (item.firstChild as HTMLAnchorElement).click();
-              state.currentHashId = item.id;
-            }
-          }
-        }
-
-        const pagePadding = 16;
-        // Dynamic set toc item when scroll page.
-        ducumentContainerRef.value?.addEventListener("scroll", () => {
-          const scrollTop = ducumentContainerRef.value?.scrollTop || 0;
-          for (let i = 0; i < tagElementList.length; i++) {
-            if (tagElementList[i].offsetTop + pagePadding > scrollTop) {
-              state.currentHashId = tagElementList[i].id;
-              break;
-            }
-          }
-
-          const scrollHeight = ducumentContainerRef.value?.scrollHeight || 0;
-          const clientHeight = ducumentContainerRef.value?.clientHeight || 0;
-          const gapTriggerValue = 128;
-          if (scrollHeight - scrollTop < clientHeight + gapTriggerValue) {
-            const { hasShownSubscribtionPopupInDocs } = storage.get([
-              "hasShownSubscribtionPopupInDocs",
-            ]);
-            if (!hasShownSubscribtionPopupInDocs) {
-              state.showSubscribtionPopup = true;
-            }
-          }
-        });
-      }
-
       // Add the `Copy` button for pre elements without plain language.
       const preElementNodeList = ducumentContainerRef.value?.querySelectorAll(
         "pre:not(.language-plain)"
@@ -300,7 +228,6 @@ export default defineComponent({
       state,
       prev,
       next,
-      toc,
       ducumentContainerRef,
       githubFilePath,
       onCloseSubscribtionPopUp,

--- a/components/Toc.vue
+++ b/components/Toc.vue
@@ -1,23 +1,23 @@
 <template>
   <!-- Table of Contents-->
   <aside
-    v-show="titlesShouldList.length > 0"
-    class="hidden xl:flex flex-col justify-start items-start sticky w-52 top-0 right-6 2xl:right-10 pr-4 h-full max-h-screen flex-shrink-0 overflow-x-hidden overflow-y-auto text-sm"
+    v-show="tocList.length > 0"
+    :class="`hidden ${breakPoint}:flex flex-col justify-start items-start sticky w-52 top-0 right-6 2xl:right-10 pr-4 h-full max-h-screen flex-shrink-0 overflow-x-hidden overflow-y-auto text-sm`"
   >
     <span class="text-black pb-2 pl-4 border-l border-gray-200 truncate"
       >Table of Contents</span
     >
     <div class="flex flex-col w-52 md:h-112 2xl:h-screen overflow-y-auto">
       <a
-        v-for="item of titlesShouldList"
+        v-for="item of tocList"
         :key="item.id"
         :border="item.text"
         class="truncate leading-7 text-gray-500 flex-shrink-0 w-full whitespace-nowrap border-l border-gray-200 pl-4 hover:text-accent"
         :class="`pl-${(item.depth - 1) * 4} ${
-          state.activeHashId === item.id ? 'text-accent border-accent' : ''
+          activeHashId === item.id ? 'text-accent border-accent' : ''
         }`"
         :href="`#${item.id}`"
-        @click="state.activeHashId = item.id"
+        @click="activeHashId = item.id"
       >
         {{ item.text }}
       </a>
@@ -32,6 +32,7 @@ import {
   onMounted,
   ref,
 } from "@nuxtjs/composition-api";
+import { sortedIndex, throttle } from "lodash";
 
 interface TOC {
   id: string;
@@ -39,90 +40,41 @@ interface TOC {
   text: string;
 }
 
-interface State {
-  activeHashId: string;
-  showTOC: boolean;
-}
-
 export default defineComponent({
-  props: { content: Object },
-  setup(props: { content: any }) {
-    const state = ref<State>({
-      activeHashId: "",
-      showTOC: false,
-    });
-    const titlesShouldList = computed(() =>
+  props: {
+    content: { type: Object, required: true },
+    scrollOffset: { type: Number, required: true },
+    breakPoint: { type: String, default: "xl" },
+  },
+  setup(props: { content: any; scrollOffset: number }) {
+    const activeHashId = ref("");
+    const tocList = computed(() =>
       (props.content.toc as TOC[]).filter((t) => t.depth >= 2 && t.depth <= 3)
     );
-    /**
-     * These IDs are recorded to detect whether the user scrolled up or down.
-     *
-     * There're only two scenarios where we need to update the active title:
-     *  1. The user scrolls down until a new title appears, then mark the new title as active.
-     *  2. The user scrolls up until the currently active title is not in view,
-     *     so we will select the previous title as the active one.
-     */
-    const lastAppearedId = ref<string>();
-    const currAppearedId = ref<string>();
-    const lastDisappearedId = ref<string>();
-    const currDisappearedId = ref<string>();
-
     onMounted(() => {
+      // eslint-disable-next-line no-undef
       if (process.client) {
-        const vh = Math.max(
-          document.documentElement.clientHeight || 0,
-          window.innerHeight || 0
+        const contentContainer = document.querySelector("#content-container");
+        const titleElementList: any = Array.from(
+          document.querySelectorAll("#content h2, #content h3")
         );
-        const options = {
-          threshold: 0.1,
-          rootMargin: `0px 0px -${vh - 214}px 0px`,
+        const onScroll = () => {
+          const scrollTop = contentContainer?.scrollTop || 0;
+          const titleOffsetTops = titleElementList
+            .map((el) => el.offsetTop)
+            .sort((a, b) => a - b);
+          const activeIndex =
+            sortedIndex(titleOffsetTops, scrollTop + props.scrollOffset) - 1;
+          if (activeIndex >= 0) {
+            activeHashId.value = titleElementList[activeIndex].id;
+          }
         };
-        const titles = Array.from(
-          document.querySelectorAll(
-            "#content-container h2, #content-container h3"
-          )
-        );
-        const Ids = titles.map((t) => t.id);
-        lastAppearedId.value = titles[0].id;
-        lastDisappearedId.value = titles[0].id;
-
-        const titleObserver = new IntersectionObserver((entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              currAppearedId.value = entry.target.id;
-              if (
-                Ids.indexOf(currAppearedId.value) >=
-                Ids.indexOf(lastAppearedId.value as string)
-              ) {
-                // When a title appears during scrolling down, make it active.
-                state.value.activeHashId = entry.target.id;
-              }
-              lastAppearedId.value = currAppearedId.value;
-            } else {
-              currDisappearedId.value = entry.target.id;
-              if (
-                Ids.indexOf(currDisappearedId.value as string) <
-                Ids.indexOf(lastDisappearedId.value as string)
-              ) {
-                // When a title disappears during scrolling up, make the title before it active.
-                if (Ids.indexOf(entry.target.id) - 1 >= 0) {
-                  state.value.activeHashId =
-                    Ids[Ids.indexOf(entry.target.id) - 1];
-                }
-              }
-              lastDisappearedId.value = currDisappearedId.value;
-            }
-          });
-        }, options);
-
-        titles.forEach((title) => {
-          titleObserver.observe(title);
-        });
+        contentContainer?.addEventListener("scroll", throttle(onScroll, 100));
       }
     });
     return {
-      state,
-      titlesShouldList,
+      activeHashId,
+      tocList,
     };
   },
 });

--- a/components/Toc.vue
+++ b/components/Toc.vue
@@ -7,7 +7,7 @@
     <span class="text-black pb-2 pl-4 border-l border-gray-200 truncate"
       >Table of Contents</span
     >
-    <div class="flex flex-col w-52 md:h-112 2xl:h-screen overflow-y-scroll">
+    <div class="flex flex-col w-52 md:h-112 2xl:h-screen overflow-y-auto">
       <a
         v-for="item of titlesShouldList"
         :key="item.id"

--- a/components/Toc.vue
+++ b/components/Toc.vue
@@ -61,8 +61,8 @@ export default defineComponent({
         const onScroll = () => {
           const scrollTop = contentContainer?.scrollTop || 0;
           const titleOffsetTops = titleElementList
-            .map((el) => el.offsetTop)
-            .sort((a, b) => a - b);
+            .map((el: any) => el.offsetTop)
+            .sort((a: number, b: number) => a - b);
           const activeIndex =
             sortedIndex(titleOffsetTops, scrollTop + props.scrollOffset) - 1;
           if (activeIndex >= 0) {

--- a/components/Toc.vue
+++ b/components/Toc.vue
@@ -69,9 +69,13 @@ export default defineComponent({
 
     onMounted(() => {
       if (process.client) {
+        const vh = Math.max(
+          document.documentElement.clientHeight || 0,
+          window.innerHeight || 0
+        );
         const options = {
           threshold: 0.1,
-          rootMargin: "0px 0px -75% 0px",
+          rootMargin: `0px 0px -${vh - 214}px 0px`,
         };
         const titles = Array.from(
           document.querySelectorAll(
@@ -97,7 +101,7 @@ export default defineComponent({
             } else {
               currDisappearedId.value = entry.target.id;
               if (
-                Ids.indexOf(currDisappearedId.value as string) <=
+                Ids.indexOf(currDisappearedId.value as string) <
                 Ids.indexOf(lastDisappearedId.value as string)
               ) {
                 // When a title disappears during scrolling up, make the title before it active.

--- a/components/Toc.vue
+++ b/components/Toc.vue
@@ -1,0 +1,125 @@
+<template>
+  <!-- Table of Contents-->
+  <aside
+    v-show="titlesShouldList.length > 0"
+    class="hidden xl:flex flex-col justify-start items-start sticky w-52 top-0 right-6 2xl:right-10 pr-4 h-full max-h-screen flex-shrink-0 overflow-x-hidden overflow-y-auto text-sm"
+  >
+    <span class="text-black pb-2 pl-4 border-l border-gray-200 truncate"
+      >Table of Contents</span
+    >
+    <div class="flex flex-col w-52 md:h-112 2xl:h-screen overflow-y-scroll">
+      <a
+        v-for="item of titlesShouldList"
+        :key="item.id"
+        :border="item.text"
+        class="truncate leading-7 text-gray-500 flex-shrink-0 w-full whitespace-nowrap border-l border-gray-200 pl-4 hover:text-accent"
+        :class="`pl-${(item.depth - 1) * 4} ${
+          state.activeHashId === item.id ? 'text-accent border-accent' : ''
+        }`"
+        :href="`#${item.id}`"
+        @click="state.activeHashId = item.id"
+      >
+        {{ item.text }}
+      </a>
+    </div>
+  </aside>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  computed,
+  onMounted,
+  ref,
+} from "@nuxtjs/composition-api";
+
+interface TOC {
+  id: string;
+  depth: number;
+  text: string;
+}
+
+interface State {
+  activeHashId: string;
+  showTOC: boolean;
+}
+
+export default defineComponent({
+  props: { content: Object },
+  setup(props: { content: any }) {
+    const state = ref<State>({
+      activeHashId: "",
+      showTOC: false,
+    });
+    const titlesShouldList = computed(() =>
+      (props.content.toc as TOC[]).filter((t) => t.depth >= 2 && t.depth <= 3)
+    );
+    /**
+     * These IDs are recorded to detect whether the user scrolled up or down.
+     *
+     * There're only two scenarios where we need to update the active title:
+     *  1. The user scrolls down until a new title appears, then mark the new title as active.
+     *  2. The user scrolls up until the currently active title is not in view,
+     *     so we will select the previous title as the active one.
+     */
+    const lastAppearedId = ref<string>();
+    const currAppearedId = ref<string>();
+    const lastDisappearedId = ref<string>();
+    const currDisappearedId = ref<string>();
+
+    onMounted(() => {
+      if (process.client) {
+        const options = {
+          threshold: 0.1,
+          rootMargin: "0px 0px -75% 0px",
+        };
+        const titles = Array.from(
+          document.querySelectorAll(
+            "#content-container h2, #content-container h3"
+          )
+        );
+        const Ids = titles.map((t) => t.id);
+        lastAppearedId.value = titles[0].id;
+        lastDisappearedId.value = titles[0].id;
+
+        const titleObserver = new IntersectionObserver((entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              currAppearedId.value = entry.target.id;
+              if (
+                Ids.indexOf(currAppearedId.value) >=
+                Ids.indexOf(lastAppearedId.value as string)
+              ) {
+                // When a title appears during scrolling down, make it active.
+                state.value.activeHashId = entry.target.id;
+              }
+              lastAppearedId.value = currAppearedId.value;
+            } else {
+              currDisappearedId.value = entry.target.id;
+              if (
+                Ids.indexOf(currDisappearedId.value as string) <=
+                Ids.indexOf(lastDisappearedId.value as string)
+              ) {
+                // When a title disappears during scrolling up, make the title before it active.
+                if (Ids.indexOf(entry.target.id) - 1 >= 0) {
+                  state.value.activeHashId =
+                    Ids[Ids.indexOf(entry.target.id) - 1];
+                }
+              }
+              lastDisappearedId.value = currDisappearedId.value;
+            }
+          });
+        }, options);
+
+        titles.forEach((title) => {
+          titleObserver.observe(title);
+        });
+      }
+    });
+    return {
+      state,
+      titlesShouldList,
+    };
+  },
+});
+</script>

--- a/components/Toc.vue
+++ b/components/Toc.vue
@@ -2,7 +2,7 @@
   <!-- Table of Contents-->
   <aside
     v-show="tocList.length > 0"
-    :class="`hidden ${breakPoint}:flex flex-col justify-start items-start sticky w-52 top-0 right-6 2xl:right-10 pr-4 h-full max-h-screen flex-shrink-0 overflow-x-hidden overflow-y-auto text-sm`"
+    class="hidden xl:flex flex-col justify-start items-start sticky w-52 top-0 right-6 2xl:right-10 pr-4 h-full max-h-screen flex-shrink-0 overflow-x-hidden overflow-y-auto text-sm"
   >
     <span class="text-black pb-2 pl-4 border-l border-gray-200 truncate"
       >Table of Contents</span
@@ -44,7 +44,6 @@ export default defineComponent({
   props: {
     content: { type: Object, required: true },
     scrollOffset: { type: Number, required: true },
-    breakPoint: { type: String, default: "xl" },
   },
   setup(props: { content: any; scrollOffset: number }) {
     const activeHashId = ref("");

--- a/layouts/blog.vue
+++ b/layouts/blog.vue
@@ -21,6 +21,7 @@
       </div>
     </div>
     <div
+      id="content-container"
       ref="contentElementRef"
       class="w-full pt-8 h-auto overflow-y-auto overflow-x-hidden"
     >

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,6 +5,7 @@
       <Header />
     </div>
     <div
+      id="content-container"
       ref="contentElementRef"
       class="w-full pt-8 h-auto overflow-y-auto overflow-x-hidden"
     >

--- a/pages/blog/_slug/index.vue
+++ b/pages/blog/_slug/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="content-container" class="space-y-8">
+  <div id="content" class="space-y-8">
     <div class="hidden sm:flex sm:h-96 w-full">
       <img
         v-if="blog.featureImage"
@@ -46,7 +46,7 @@
         class="w-full px-4 py-6 prose prose-indigo prose-xl 2xl:prose-2xl mx-auto"
         :document="blog"
       />
-      <Toc :content="blog" />
+      <Toc :content="blog" :scroll-offset="200" />
     </div>
   </div>
 </template>

--- a/pages/blog/_slug/index.vue
+++ b/pages/blog/_slug/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="space-y-8">
+  <div id="content-container" class="space-y-8">
     <div class="hidden sm:flex sm:h-96 w-full">
       <img
         v-if="blog.featureImage"
@@ -46,55 +46,20 @@
         class="w-full px-4 py-6 prose prose-indigo prose-xl 2xl:prose-2xl mx-auto"
         :document="blog"
       />
-      <!-- TOC -->
-      <aside
-        class="hidden xl:flex flex-col justify-start items-start sticky w-52 top-0 right-6 2xl:right-10 pr-4 h-full max-h-screen flex-shrink-0 overflow-x-hidden overflow-y-auto text-sm"
-      >
-        <span class="text-black pb-2 pl-4 border-l border-gray-200 truncate"
-          >Table of Contents</span
-        >
-        <div class="flex flex-col w-52 md:h-112 2xl:h-screen overflow-y-scroll">
-          <a
-            v-for="item of toc"
-            :key="item.id"
-            :border="item.text"
-            class="truncate leading-7 text-gray-500 flex-shrink-0 w-full whitespace-nowrap border-l border-gray-200 pl-4 hover:text-accent"
-            :class="`pl-${(item.depth - 1) * 4} ${
-              state.currentHashId === item.id ? 'text-accent border-accent' : ''
-            }`"
-            :href="`#${item.id}`"
-            @click="state.currentHashId = item.id"
-          >
-            {{ item.text }}
-          </a>
-        </div>
-      </aside>
+      <Toc :content="blog" />
     </div>
   </div>
 </template>
 
 <script lang="ts">
+import Toc from "~/components/Toc.vue";
 import { lowerCase, startsWith } from "lodash";
 import { getTeammateByName } from "~/common/teammate";
 import { calcReadingTime } from "~/common/utils";
 import { PostTag, postTagStyle } from "../../../common/type";
 
-interface TOC {
-  id: string;
-  depth: number;
-  text: string;
-}
-
-interface State {
-  currentHashId: string;
-  showTOC: boolean;
-}
-
-interface Data {
-  state: State;
-}
-
 export default {
+  components: { Toc },
   layout: "blog",
   async asyncData({ params, $content }: any) {
     const data = await $content("blog", params.slug, {
@@ -121,14 +86,6 @@ export default {
 
     return {
       blog,
-    };
-  },
-  data(): Data {
-    return {
-      state: {
-        currentHashId: "",
-        showTOC: false,
-      },
     };
   },
   head() {
@@ -168,31 +125,6 @@ export default {
         },
       ],
     };
-  },
-  computed: {
-    toc(): TOC[] {
-      return ((this as any).blog.toc as TOC[]).filter(
-        (t) => t.depth >= 2 && t.depth <= 3
-      );
-    },
-  },
-  mounted() {
-    if (process.client) {
-      const options = {
-        threshold: 0.1,
-      };
-      const titles = document.querySelectorAll("h2, h3");
-      const titleObserver = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            (this as any).state.currentHashId = entry.target.id;
-          }
-        });
-      }, options);
-      titles.forEach((title) => {
-        titleObserver.observe(title);
-      });
-    }
   },
   methods: {
     getTagStyle(tag: PostTag): string {

--- a/pages/blog/_slug/index.vue
+++ b/pages/blog/_slug/index.vue
@@ -39,10 +39,37 @@
         <span>{{ blog.readingTime }}</span>
       </div>
     </div>
-    <nuxt-content
-      class="w-full px-4 py-6 prose prose-indigo sm:prose-xl md:prose-2xl mx-auto"
-      :document="blog"
-    />
+    <div class="flex flex-row">
+      <!-- An empty block on the left side for layout -->
+      <aside class="w-52 hidden xl:flex" />
+      <nuxt-content
+        class="w-full px-4 py-6 prose prose-indigo prose-xl 2xl:prose-2xl mx-auto"
+        :document="blog"
+      />
+      <!-- TOC -->
+      <aside
+        class="hidden xl:flex flex-col justify-start items-start sticky w-52 top-0 right-6 2xl:right-10 pr-4 h-full max-h-screen flex-shrink-0 overflow-x-hidden overflow-y-auto text-sm"
+      >
+        <span class="text-black pb-2 pl-4 border-l border-gray-200 truncate"
+          >Table of Contents</span
+        >
+        <div class="flex flex-col w-52 md:h-112 2xl:h-screen overflow-y-scroll">
+          <a
+            v-for="item of toc"
+            :key="item.id"
+            :border="item.text"
+            class="truncate leading-7 text-gray-500 flex-shrink-0 w-full whitespace-nowrap border-l border-gray-200 pl-4 hover:text-accent"
+            :class="`pl-${(item.depth - 1) * 4} ${
+              state.currentHashId === item.id ? 'text-accent border-accent' : ''
+            }`"
+            :href="`#${item.id}`"
+            @click="state.currentHashId = item.id"
+          >
+            {{ item.text }}
+          </a>
+        </div>
+      </aside>
+    </div>
   </div>
 </template>
 
@@ -51,6 +78,21 @@ import { lowerCase, startsWith } from "lodash";
 import { getTeammateByName } from "~/common/teammate";
 import { calcReadingTime } from "~/common/utils";
 import { PostTag, postTagStyle } from "../../../common/type";
+
+interface TOC {
+  id: string;
+  depth: number;
+  text: string;
+}
+
+interface State {
+  currentHashId: string;
+  showTOC: boolean;
+}
+
+interface Data {
+  state: State;
+}
 
 export default {
   layout: "blog",
@@ -79,6 +121,14 @@ export default {
 
     return {
       blog,
+    };
+  },
+  data(): Data {
+    return {
+      state: {
+        currentHashId: "",
+        showTOC: false,
+      },
     };
   },
   head() {
@@ -118,6 +168,31 @@ export default {
         },
       ],
     };
+  },
+  computed: {
+    toc(): TOC[] {
+      return ((this as any).blog.toc as TOC[]).filter(
+        (t) => t.depth >= 2 && t.depth <= 3
+      );
+    },
+  },
+  mounted() {
+    if (process.client) {
+      const options = {
+        threshold: 0.1,
+      };
+      const titles = document.querySelectorAll("h2, h3");
+      const titleObserver = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            (this as any).state.currentHashId = entry.target.id;
+          }
+        });
+      }, options);
+      titles.forEach((title) => {
+        titleObserver.observe(title);
+      });
+    }
   },
   methods: {
     getTagStyle(tag: PostTag): string {

--- a/pages/changelog/_slug/index.vue
+++ b/pages/changelog/_slug/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="overflow-hidden space-y-8">
+  <main id="content-container" class="space-y-8">
     <div class="prose sm:prose-xl md:prose-2xl mx-auto text-center">
       <img
         v-if="changelog.featureImage"
@@ -27,10 +27,14 @@
         </template>
       </div>
     </div>
-    <nuxt-content
-      class="w-full px-4 py-6 prose prose-indigo sm:prose-xl md:prose-2xl mx-auto"
-      :document="changelog"
-    />
+    <div class="flex flex-row">
+      <aside class="w-52 hidden xl:flex" />
+      <nuxt-content
+        class="w-full px-4 py-6 prose prose-indigo prose-xl 2xl:prose-2xl mx-auto"
+        :document="changelog"
+      />
+      <Toc :content="changelog" />
+    </div>
   </main>
 </template>
 
@@ -38,8 +42,10 @@
 import { lowerCase, startsWith } from "lodash";
 import { getTeammateByName } from "~/common/teammate";
 import { calcReadingTime } from "~/common/utils";
+import Toc from "~/components/Toc.vue";
 
 export default {
+  components: { Toc },
   async asyncData({ params, $content }: any) {
     const data = await $content("changelog", params.slug, {
       deep: true,

--- a/pages/changelog/_slug/index.vue
+++ b/pages/changelog/_slug/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <main id="content-container" class="space-y-8">
+  <main class="space-y-8">
     <div class="prose sm:prose-xl md:prose-2xl mx-auto text-center">
       <img
         v-if="changelog.featureImage"
@@ -27,13 +27,13 @@
         </template>
       </div>
     </div>
-    <div class="flex flex-row">
+    <div id="content" class="flex flex-row">
       <aside class="w-52 hidden xl:flex" />
       <nuxt-content
         class="w-full px-4 py-6 prose prose-indigo prose-xl 2xl:prose-2xl mx-auto"
         :document="changelog"
       />
-      <Toc :content="changelog" />
+      <Toc :content="changelog" :scroll-offset="135" />
     </div>
   </main>
 </template>

--- a/pages/changelog/index.vue
+++ b/pages/changelog/index.vue
@@ -72,7 +72,7 @@
                 </div>
               </nuxt-link>
               <nuxt-content
-                class="w-full py-6 prose prose-indigo sm:prose-xl md:prose-2xl mx-auto"
+                class="w-full py-6 prose prose-indigo prose-xl 2xl:prose-2xl mx-auto"
                 :document="changelog"
               />
             </div>
@@ -101,16 +101,16 @@ export default {
         (a: any, b: any) =>
           new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
       )
-      .map((changlog: any) => {
-        const author = getTeammateByName(changlog.author) as any;
+      .map((changelog: any) => {
+        const author = getTeammateByName(changelog.author) as any;
         if (author) {
           author.avatar = `${lowerCase(author?.name)}.webp`;
         }
 
         return {
-          ...changlog,
+          ...changelog,
           author: author,
-          formatedPublishedAt: new Date(changlog.publishedAt).toLocaleString(
+          formatedPublishedAt: new Date(changelog.publishedAt).toLocaleString(
             "default",
             {
               year: "numeric",
@@ -118,7 +118,7 @@ export default {
               day: "numeric",
             }
           ),
-          readingTime: calcReadingTime(changlog.bodyPlainText),
+          readingTime: calcReadingTime(changelog.bodyPlainText),
         };
       });
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,34 @@ module.exports = {
             img: {
               width: "100%",
             },
+            code: {
+              padding: "0 0.4em",
+              margin: 0,
+              fontSize: "1em",
+              backgroundColor: "#f5f2f0",
+              borderRadius: "6px",
+              fontWeight: "inherit",
+              color: "inherit",
+            },
+            "code:before": {
+              content: "none",
+            },
+            "code:after": {
+              content: "none",
+            },
+          },
+        },
+        xl: {
+          css: {
+            code: {
+              padding: "0 0.4em",
+              margin: 0,
+              fontSize: "1em",
+              backgroundColor: "#f5f2f0",
+              borderRadius: "6px",
+              fontWeight: "inherit",
+              color: "inherit",
+            },
           },
         },
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,11 +25,14 @@ module.exports = {
         208: "52rem",
       },
       typography: {
+        // These configs are to override the default `prose` theme.
         DEFAULT: {
           css: {
+            // Make images fill the horizontal space.
             img: {
               width: "100%",
             },
+            // Add background to inline code.
             code: {
               padding: "0 0.4em",
               margin: 0,
@@ -39,6 +42,7 @@ module.exports = {
               fontWeight: "inherit",
               color: "inherit",
             },
+            // Remove backticks of inline code.
             "code:before": {
               content: "none",
             },
@@ -47,6 +51,7 @@ module.exports = {
             },
           },
         },
+        // Apply same configs to `xl` screens.
         xl: {
           css: {
             code: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,6 +24,15 @@ module.exports = {
         192: "48rem",
         208: "52rem",
       },
+      typography: {
+        DEFAULT: {
+          css: {
+            img: {
+              width: "100%",
+            },
+          },
+        },
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
### Features
1. Override some default style provided by [@tailwindcss/typography](https://tailwindcss.com/docs/typography-plugin).
    - Remove rounding backticks of inline code and improve its style.

        | before | after |
        |:--:|:--:|
        | ![image](https://user-images.githubusercontent.com/56376387/175248529-e17aa952-b75c-45dc-878f-f5f7cf5c2c47.png) | ![image](https://user-images.githubusercontent.com/56376387/175249334-a82625c4-94ce-457e-adcc-711aec7a8a7a.png) |
    - Center images and fill the horizontal space.

        | before | after |
        |:--:|:--:|
        | ![image](https://user-images.githubusercontent.com/56376387/175249785-d472e181-4538-46d4-85ea-d4df80a88e57.png) | ![image](https://user-images.githubusercontent.com/56376387/175249943-a3c5d7e8-8cc8-4e52-b0b7-86b4ed7d372d.png) |
2. Add table of contents to blog/changelog page.

https://user-images.githubusercontent.com/56376387/175276292-7d3cc3a3-ff53-43b6-b4ea-f9db3b8eceb1.mp4
