### PR TITLE
docs(changelog): change long inline code to code block

### DIFF
--- a/content/changelog/bytebase-1-0-4.md
+++ b/content/changelog/bytebase-1-0-4.md
@@ -17,7 +17,13 @@ Support data source name (DSN) formats to connect databases in CLI, e.g. `--dsn 
 
 ### Add installation script of bb CLI
 
-User can install `bb` CLI with only one command `/bin/bash -c "$(curl -fsSL [https://raw.githubusercontent.com/bytebase/install/HEAD/install.sh)"](https://raw.githubusercontent.com/bytebase/install/HEAD/install.sh)&quot;)` . Previously, users needed to go through several steps from downloading on GitHub Release, decompressing and manually moving the files to executable file directory.
+User can install `bb` CLI with only one command. 
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/bytebase/bytebase/HEAD/scripts/install_bb.sh)"
+```
+
+Previously, users needed to go through several steps from downloading on GitHub Release, decompressing and manually moving the files to executable file directory.
 
 ### Add dashboard page to manage all SQL sheets
 


### PR DESCRIPTION
### Docs Change
- Change inline code to code block in changelog *Bytebase 1.0.4*.
    | before | after |
    |:--:|:--:|
    | ![image](https://user-images.githubusercontent.com/56376387/175277344-79ac5242-2832-4448-98e9-6d2a14d6ac29.png) | ![image](https://user-images.githubusercontent.com/56376387/175277191-a7794e53-8ce6-4933-ad34-3b3ef795400d.png) |