### PR TITLE
docs: adjust founder section padding to align text

### DIFF
--- a/components/TeamSection.vue
+++ b/components/TeamSection.vue
@@ -20,7 +20,7 @@
                   :src="require(`~/assets/people/${person.imageUrl}`)"
                   alt=""
                 />
-                <div class="col-span-3 text-left">
+                <div class="col-span-3 text-left pt-4">
                   <div class="space-y-4">
                     <div class="text-lg leading-6 font-medium space-y-1">
                       <h3>{{ person.name }}</h3>


### PR DESCRIPTION
Before
![CleanShot 2022-07-03 at 17 56 53](https://user-images.githubusercontent.com/230323/177034617-d25bcfa6-30d8-4c50-a64e-c4dd33288473.png)

After
![CleanShot 2022-07-03 at 17 57 04](https://user-images.githubusercontent.com/230323/177034620-d28e8fa7-4e58-4536-899c-bab86e3bdeeb.png)

