### PR TITLE
fix: docs header style in mobile

### DIFF
--- a/layouts/content.vue
+++ b/layouts/content.vue
@@ -32,19 +32,19 @@
         >
         <nuxt-link
           to="/blog"
-          class="header-link"
+          class="header-link hidden sm:block"
           @click.native="track('blog.header')"
           >Blog</nuxt-link
         >
         <nuxt-link
           :to="localePath('/changelog')"
-          class="header-link"
+          class="header-link hidden sm:block"
           @click.native="track('changelog.header')"
           >Changelog</nuxt-link
         >
         <nuxt-link
           :to="localePath('/pricing')"
-          class="header-link"
+          class="header-link hidden sm:block"
           @click.native="track('pricing.header')"
           >Pricing</nuxt-link
         >
@@ -61,14 +61,14 @@
           <a
             href="https://demo.bytebase.com?ref=bytebase.com"
             target="_blank"
-            class="ml-2 flex items-center justify-center whitespace-nowrap px-3 h-8 border border-transparent text-sm font-medium rounded border-gray-200 text-gray-700 bg-gray-100 hover:bg-gray-300"
+            class="ml-2 hidden sm:flex items-center justify-center whitespace-nowrap px-3 h-8 border border-transparent text-sm font-medium rounded border-gray-200 text-gray-700 bg-gray-100 hover:bg-gray-300"
             @click="track('demo.header')"
           >
             Demo
           </a>
           <nuxt-link
             :to="localePath('/docs/install/install-with-docker')"
-            class="ml-2 flex items-center justify-center whitespace-nowrap px-3 h-8 text-sm font-medium rounded text-white bg-green-500 hover:bg-green-600"
+            class="ml-2 hidden sm:flex items-center justify-center whitespace-nowrap px-3 h-8 text-sm font-medium rounded text-white bg-green-500 hover:bg-green-600"
             @click.native="track('deploy.header')"
             >Deploy now</nuxt-link
           >
@@ -216,6 +216,6 @@ export default defineComponent({
   @apply font-normal;
 }
 .DocSearch-Button-Container > .DocSearch-Search-Icon {
-  @apply w-4 h-auto ml-1;
+  @apply w-4 h-auto mx-0.5 sm:ml-1;
 }
 </style>


### PR DESCRIPTION
Hide other(blog/changelog/pricing) entry temporarily to fix the broken docs header in mobile.

|before|after|
|-|-|
|<img width="440" alt="image" src="https://user-images.githubusercontent.com/24653555/177064168-60e3d270-dc78-4905-94ad-5a321de40278.png">|<img width="432" alt="image" src="https://user-images.githubusercontent.com/24653555/177064184-628cf91a-51e4-426d-bf96-8a0fe172990f.png">|