### PR TITLE
feat: add a global version component

### DIFF
--- a/components/global/Version.vue
+++ b/components/global/Version.vue
@@ -1,0 +1,4 @@
+<template>
+  <!-- change the latest version below after every publish -->
+  <span>1.2.0</span>
+</template>

--- a/content/docs/en/get-started/deploy-to-production/deploy-with-docker.md
+++ b/content/docs/en/get-started/deploy-to-production/deploy-with-docker.md
@@ -9,36 +9,38 @@ Before starting, make sure you have installed [Docker](https://www.docker.com/ge
 
 ## Run on localhost:8080 or localhost:xxxx
 Run the following command to start Bytebase locally on localhost:8080.
-```
+<pre>
 docker run --init \
   --name bytebase \
   --restart always \
   --add-host host.docker.internal:host-gateway \
   --publish 8080:8080 \
   --volume ~/.bytebase/data:/var/opt/bytebase \
-  bytebase/bytebase:1.2.0 \
+  bytebase/bytebase:<version></version> \
   --data /var/opt/bytebase \
   --host http://localhost \
   --port 8080
-```
+</pre>
+
+
 
 You can change `8080` to `5678` or something else, however, make sure these three ports are the same:
 - --publish {{hostport}}
 - :{{containerport}} 
 - --port {{port}}}
 
-```
+<pre>
 docker run --init \
   --name bytebase \
   --restart always \
   --add-host host.docker.internal:host-gateway \
   --publish 5678:5678 \
   --volume ~/.bytebase/data:/var/opt/bytebase \
-  bytebase/bytebase:1.2.0 \
+  bytebase/bytebase:<version></version> \
   --data /var/opt/bytebase \
   --host http://localhost \
   --port 5678
-```
+</pre>
 
 Bytebase will store its data under `~/.bytebase/data` , you can reset all data by running command:
   
@@ -52,18 +54,18 @@ Check [Server Startup Options](./reference/command-line) for other startup optio
 
 Run the following command to start Bytebase on [https://bytebase.example.com](https://bytebase.example.com/)
 
-```
+<pre>
 docker run --init \
   --name bytebase \
   --restart always \
   --add-host host.docker.internal:host-gateway \
   --publish 80:80 \
   --volume ~/.bytebase/data:/var/opt/bytebase \
-  bytebase/bytebase:1.2.0 \
+  bytebase/bytebase:<version></version> \
   --data /var/opt/bytebase \
   --host https://bytebase.example.com \
   --port 80
-```
+</pre>
 
 <hint-block type="info">
 
@@ -80,7 +82,7 @@ docker logs bytebase
 
 Normally you should see this:
 
-```
+<pre>
 -----Config BEGIN-----
 mode=release
 host=http://example.com
@@ -104,8 +106,8 @@ debug=false
 ██████╔╝   ██║      ██║   ███████╗██████╔╝██║  ██║███████║███████╗
 ╚═════╝    ╚═╝      ╚═╝   ╚══════╝╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝
 
-Version 1.2.0 has started at http://example.com:8080
-```
+Version <version></version> has started at http://example.com:8080
+</pre>
 
 ### Unable to start Bytebase with Docker
 

--- a/content/docs/en/get-started/deploy-to-production/installation-script.md
+++ b/content/docs/en/get-started/deploy-to-production/installation-script.md
@@ -2,7 +2,7 @@
 title: Installation Script
 ---
 
-**Latest release version:** [**1.2.0**](https://github.com/bytebase/bytebase/releases/tag/1.2.0)
+**Latest release version:** [**<version></version>**](https://github.com/bytebase/bytebase/releases/latest) 
 
 ## Prerequisite
 

--- a/content/docs/en/get-started/quick-start.md
+++ b/content/docs/en/get-started/quick-start.md
@@ -15,19 +15,19 @@ Before starting, make sure you have installed [Docker](https://www.docker.com/ge
 1. Start Docker.
 2. Open Terminal to run the command:
 
-```
-curl -fsS https://raw.githubusercontent.com/bytebase/bytebase/main/quickstart/getting-started.docker-compose.yml | BB_VERSION=1.2.0 docker-compose -f - up
-```
+<pre>
+curl -fsS https://raw.githubusercontent.com/bytebase/bytebase/main/quickstart/getting-started.docker-compose.yml | BB_VERSION=<version></version> docker-compose -f - up
+</pre>
 
 If the above command doesn't work, use the proxy version:
 
-```
-curl -fsS https://ghproxy.com/https://raw.githubusercontent.com/bytebase/bytebase/main/quickstart/getting-started.docker-compose.yml | BB_VERSION=1.2.0 docker-compose -f - up
-```
+<pre>
+curl -fsS https://ghproxy.com/https://raw.githubusercontent.com/bytebase/bytebase/main/quickstart/getting-started.docker-compose.yml | BB_VERSION=<version></version> docker-compose -f - up
+</pre>
 
 When the Terminal shows the following message, the execution is successful.
 
-```
+<pre>
   employee-prod_1  | 2022-06-21T02:35:01.128005Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.29) starting as process 63
   employee-prod_1  | 2022-06-21T02:35:01.150847Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
   bytebase         | 2022-06-21T02:35:01.449Z	INFO	Completed database initial migration with version 1.1.2.
@@ -43,11 +43,11 @@ When the Terminal shows the following message, the execution is successful.
   bytebase         | ██████╔╝   ██║      ██║   ███████╗██████╔╝██║  ██║███████║███████╗
   bytebase         | ╚═════╝    ╚═╝      ╚═╝   ╚══════╝╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝
   bytebase         |
-  bytebase         | Version 1.2.0 has started at <http://localhost:5678>
+  bytebase         | Version <version></version> has started at <http://localhost:5678>
   bytebase         | ___________________________________________________________________________________________
   bytebase         |
   employee-test_1  | [Entrypoint] Database initialized
-```
+</pre>
 
 Now you have three Docker containers running:
 


### PR DESCRIPTION
Added a global version component which contains the latest version number. Now we just need to change one place after we publish a new version.

After some investigation, I found out that a [MarkDoc-like](https://markdoc.io/docs/variables) **variable** is not supported in Nuxt Content currently: https://github.com/nuxt/content/issues/997#issuecomment-1005507397.

So I'm actually using a **component** here. A `Version` component may not be an elegant way to achieve this, but it works.
