### PR TITLE
chore: generate sitemap manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@nuxt/vue-app": "^2.15.8",
     "@nuxtjs/composition-api": "^0.32.0",
     "@nuxtjs/i18n": "^7.2.2",
-    "@nuxtjs/sitemap": "^2.4.0",
     "@pinia/nuxt": "^0.1.8",
     "@segment/analytics-next": "^1.34.0",
     "@tailwindcss/aspect-ratio": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,6 @@ specifiers:
   '@nuxtjs/composition-api': ^0.32.0
   '@nuxtjs/google-analytics': ^2.4.0
   '@nuxtjs/i18n': ^7.2.2
-  '@nuxtjs/sitemap': ^2.4.0
   '@nuxtjs/tailwindcss': ^4.2.0
   '@nuxtjs/web-vitals': ^0.1.8
   '@pinia/nuxt': ^0.1.8
@@ -64,7 +63,6 @@ dependencies:
   '@nuxt/vue-app': 2.15.8
   '@nuxtjs/composition-api': 0.32.0_kyrhbzwnikicxahddidell2iai
   '@nuxtjs/i18n': 7.2.2
-  '@nuxtjs/sitemap': 2.4.0
   '@pinia/nuxt': 0.1.9_pinia@2.0.14+vue@2.6.14
   '@segment/analytics-next': 1.36.0
   '@tailwindcss/aspect-ratio': 0.4.0_tailwindcss@2.2.19
@@ -2189,21 +2187,6 @@ packages:
       - supports-color
     dev: false
 
-  /@nuxtjs/sitemap/2.4.0:
-    resolution: {integrity: sha512-TVgIYOtPp7KAfaUo76WRpGbO20j4D/xi/A7shFIGjARHs+FvfAWXNCtBT87dTwe/RoYzAsEKtijFFUTaSu5bUA==}
-    engines: {node: '>=8.9.0', npm: '>=5.0.0'}
-    dependencies:
-      async-cache: 1.1.0
-      consola: 2.15.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      fs-extra: 8.1.0
-      is-https: 2.0.2
-      lodash.unionby: 4.8.0
-      minimatch: 3.1.2
-      sitemap: 4.1.1
-    dev: false
-
   /@nuxtjs/tailwindcss/4.2.1_webpack@4.46.0:
     resolution: {integrity: sha512-Sku7VETunn5YmvzkXFDuRdP1gUGau02eh5HtcAsI9//1hpSuEN49n3XhatBrPOXQ57WhUlnjXf0/LjT9KQH0+A==}
     dependencies:
@@ -3431,10 +3414,6 @@ packages:
   /@types/node/12.20.12:
     resolution: {integrity: sha512-KQZ1al2hKOONAs2MFv+yTQP1LkDWMrRJ9YCVRalXltOfXsBmH5IownLxQaiq0lnAHwAViLnh2aTYqrPcRGEbgg==}
 
-  /@types/node/12.20.52:
-    resolution: {integrity: sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==}
-    dev: false
-
   /@types/node/17.0.33:
     resolution: {integrity: sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ==}
 
@@ -3477,12 +3456,6 @@ packages:
     resolution: {integrity: sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==}
     dependencies:
       '@types/node': 12.20.12
-
-  /@types/sax/1.2.4:
-    resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
-    dependencies:
-      '@types/node': 12.20.52
-    dev: false
 
   /@types/serve-static/1.13.9:
     resolution: {integrity: sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==}
@@ -4298,13 +4271,6 @@ packages:
   /assign-symbols/1.0.0:
     resolution: {integrity: sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=}
     engines: {node: '>=0.10.0'}
-
-  /async-cache/1.1.0:
-    resolution: {integrity: sha1-SppaidBl7F2OUlS9nulrp2xTK1o=}
-    deprecated: No longer maintained. Use [lru-cache](http://npm.im/lru-cache) version 7.6 or higher, and provide an asynchronous `fetchMethod` option.
-    dependencies:
-      lru-cache: 4.1.5
-    dev: false
 
   /async-each/1.0.3:
     resolution: {integrity: sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==}
@@ -5127,7 +5093,7 @@ packages:
       lodash: ^4.17.20
       marko: ^3.14.4
       mote: ^0.2.0
-      mustache: ^3.0.0
+      mustache: ^4.0.1
       nunjucks: ^3.2.2
       plates: ~0.4.11
       pug: ^3.0.0
@@ -7494,10 +7460,6 @@ packages:
     resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
     dev: false
 
-  /is-https/2.0.2:
-    resolution: {integrity: sha512-UfUCKVQH/6PQRCh5Qk9vNu4feLZiFmV/gr8DjbtJD0IrCRIDTA6E+d/AVFGPulI5tqK5W45fYbn1Nir1O99rFw==}
-    dev: false
-
   /is-https/4.0.0:
     resolution: {integrity: sha512-FeMLiqf8E5g6SdiVJsPcNZX8k4h2fBs1wp5Bb6uaNxn58ufK1axBqQZdmAQsqh0t9BuwFObybrdVJh6MKyPlyg==}
     dev: false
@@ -7949,10 +7911,6 @@ packages:
 
   /lodash.topath/4.5.2:
     resolution: {integrity: sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=}
-
-  /lodash.unionby/4.8.0:
-    resolution: {integrity: sha1-iD8Jj/ePVkpye3UI4JzdU5c0u4M=}
-    dev: false
 
   /lodash.uniq/4.5.0:
     resolution: {integrity: sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=}
@@ -10848,18 +10806,6 @@ packages:
       totalist: 1.1.0
     dev: false
 
-  /sitemap/4.1.1:
-    resolution: {integrity: sha512-+8yd66IxyIFEMFkFpVoPuoPwBvdiL7Ap/HS5YD7igqO4phkyTPFIprCAE9NMHehAY5ZGN3MkAze4lDrOAX3sVQ==}
-    engines: {node: '>=8.9.0', npm: '>=5.6.0'}
-    hasBin: true
-    dependencies:
-      '@types/node': 12.20.52
-      '@types/sax': 1.2.4
-      arg: 4.1.3
-      sax: 1.2.4
-      xmlbuilder: 13.0.2
-    dev: false
-
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -12416,11 +12362,6 @@ packages:
   /xmlbuilder/11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
-    dev: false
-
-  /xmlbuilder/13.0.2:
-    resolution: {integrity: sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==}
-    engines: {node: '>=6.0'}
     dev: false
 
   /xtend/4.0.2:


### PR DESCRIPTION
The new `nuxt` uses crawler to generate routes, but the old `@nuxtjs/sitemap` could not get them at all. So we need to generate the `sitemap.xml` manually.

* https://nuxtjs.org/docs/configuration-glossary/configuration-generate#routes