### PR TITLE
style: apply shadow and width changes to changelog images

### DIFF
--- a/pages/changelog/_slug/index.vue
+++ b/pages/changelog/_slug/index.vue
@@ -31,7 +31,7 @@
     <div id="content" class="flex flex-row">
       <aside class="w-52 hidden xl:flex" />
       <nuxt-content
-        class="w-full px-4 py-6 prose prose-indigo prose-xl 2xl:prose-2xl mx-auto"
+        class="changelog-content w-full px-4 py-6 prose prose-indigo prose-xl 2xl:prose-2xl mx-auto"
         :document="changelog"
       />
       <Toc :content="changelog" :scroll-offset="135" />
@@ -117,3 +117,16 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+/* overwrite prose default styles */
+.changelog-content img {
+  width: auto !important;
+  margin: 0 auto;
+  box-shadow: 0px 36px 89px rgb(0 0 0 / 4%),
+    0px 23.3333px 52.1227px rgb(0 0 0 / 3%),
+    0px 13.8667px 28.3481px rgb(0 0 0 / 2%), 0px 7.2px 14.4625px rgb(0 0 0 / 2%),
+    0px 2.93333px 7.25185px rgb(0 0 0 / 2%),
+    0px 0.666667px 3.50231px rgb(0 0 0 / 1%) !important;
+}
+</style>

--- a/pages/changelog/index.vue
+++ b/pages/changelog/index.vue
@@ -67,7 +67,7 @@
                 </div>
               </nuxt-link>
               <nuxt-content
-                class="w-full py-6 prose prose-indigo prose-xl mx-auto"
+                class="changelog-content w-full py-6 prose prose-indigo prose-xl mx-auto"
                 :document="latestChangelog"
               />
             </div>
@@ -172,3 +172,16 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+/* overwrite prose default styles */
+.changelog-content img {
+  width: auto !important;
+  margin: 0 auto;
+  box-shadow: 0px 36px 89px rgb(0 0 0 / 4%),
+    0px 23.3333px 52.1227px rgb(0 0 0 / 3%),
+    0px 13.8667px 28.3481px rgb(0 0 0 / 2%), 0px 7.2px 14.4625px rgb(0 0 0 / 2%),
+    0px 2.93333px 7.25185px rgb(0 0 0 / 2%),
+    0px 0.666667px 3.50231px rgb(0 0 0 / 1%) !important;
+}
+</style>


### PR DESCRIPTION
Style changes only on **changelog** images:
- Added box-shadow.
- Preserve the original width of images.

| Before | After |
| :---: | :---: |
| <img width="1454" alt="CleanShot 2022-08-02 at 15 09 11@2x" src="https://user-images.githubusercontent.com/56376387/182313726-9aae31c0-4e08-4553-bcdf-000b3e2272ce.png"> | <img width="1453" alt="CleanShot 2022-08-02 at 15 09 40@2x" src="https://user-images.githubusercontent.com/56376387/182313814-25c160cc-561b-4078-84f3-37a133c3cb10.png"> |


