### PR TITLE
fix: demo entry page cannot get to demo videos

### DIFF
--- a/pages/demo/index.vue
+++ b/pages/demo/index.vue
@@ -161,10 +161,9 @@ export default defineComponent({
     onMounted(() => {
       watchEffect(() => {
         analytics.newsletter = useSegment().analyticsForNewsletter as Metric;
+        auth0.value = useAuth0();
+        analytics.other = useSegment().analytics as Metric;
       });
-
-      auth0.value = useAuth0();
-      analytics.other = useSegment().analytics as Metric;
     });
 
     return {


### PR DESCRIPTION
Fix: https://www.bytebase.com/zh/demo click on *视频演示* not working.

<img width="480" alt="CleanShot 2022-08-11 at 17 25 17@2x" src="https://user-images.githubusercontent.com/56376387/184103533-0debd849-77cc-4ffd-8be8-6f7ecb9f0e1c.png">
