### PR TITLE
refactor: inject bb_version before content parse

### DIFF
--- a/components/global/Version.vue
+++ b/components/global/Version.vue
@@ -1,9 +1,0 @@
-<template>
-  <span>{{ VERSION }}</span>
-</template>
-
-<script setup lang="ts">
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import { default as VERSION } from "!raw-loader!../../VERSION";
-</script>

--- a/content/docs/en/get-started/install/deploy-to-kubernetes.md
+++ b/content/docs/en/get-started/install/deploy-to-kubernetes.md
@@ -12,7 +12,7 @@ Before starting, make sure you are familiar with [Docker](https://www.docker.com
 
 Here is a sample Kubernetes YAML file `bb.yaml` describing the minimal components and configuration required to run Bytebase locally.
 
-<pre lang="yaml">
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: bytebase
-        image: bytebase/bytebase:<version></version>
+        image: bytebase/bytebase:%%bb_version%%
         args: ["--data", "/var/opt/bytebase", "--host", "http://localhost", "--port", "8080", "--pg", "postgresql://user:secret@host:port/dbname"]
         ports:
         - containerPort: 8080
@@ -53,7 +53,7 @@ spec:
   - protocol: TCP
     port: 8080
     targetPort: 8080
-</pre>
+```
 
 1. Start Bytebase with the following command:
 

--- a/content/docs/en/get-started/install/deploy-with-docker.md
+++ b/content/docs/en/get-started/install/deploy-with-docker.md
@@ -12,18 +12,18 @@ Before starting, make sure you have installed [Docker](https://www.docker.com/ge
 
 Run the following command to start Bytebase locally on localhost:8080.
 
-<pre>
+```bash
 docker run --init \
   --name bytebase \
   --restart always \
   --add-host host.docker.internal:host-gateway \
   --publish 8080:8080 \
   --volume ~/.bytebase/data:/var/opt/bytebase \
-  bytebase/bytebase:<version></version> \
+  bytebase/bytebase:%%bb_version%% \
   --data /var/opt/bytebase \
   --host http://localhost \
   --port 8080
-</pre>
+```
 
 You can change `8080` to `5678` or something else, however, make sure these three ports are the same:
 
@@ -31,18 +31,18 @@ You can change `8080` to `5678` or something else, however, make sure these thre
 - :{{containerport}}
 - --port {{port}}}
 
-<pre>
+```bash
 docker run --init \
   --name bytebase \
   --restart always \
   --add-host host.docker.internal:host-gateway \
   --publish 5678:5678 \
   --volume ~/.bytebase/data:/var/opt/bytebase \
-  bytebase/bytebase:<version></version> \
+  bytebase/bytebase:%%bb_version%% \
   --data /var/opt/bytebase \
   --host http://localhost \
   --port 5678
-</pre>
+```
 
 Bytebase will store its data under `~/.bytebase/data` , you can reset all data by running command:
 
@@ -56,18 +56,18 @@ Check [Server Startup Options](./reference/command-line) for other startup optio
 
 Run the following command to start Bytebase on [https://bytebase.example.com](https://bytebase.example.com/)
 
-<pre>
+```bash
 docker run --init \
   --name bytebase \
   --restart always \
   --add-host host.docker.internal:host-gateway \
   --publish 80:80 \
   --volume ~/.bytebase/data:/var/opt/bytebase \
-  bytebase/bytebase:<version></version> \
+  bytebase/bytebase:%%bb_version%% \
   --data /var/opt/bytebase \
   --host https://bytebase.example.com \
   --port 80
-</pre>
+```
 
 <hint-block type="info">
 
@@ -85,7 +85,7 @@ docker logs bytebase
 
 Normally you should see this:
 
-<pre>
+```
 -----Config BEGIN-----
 mode=release
 host=http://example.com
@@ -109,8 +109,8 @@ debug=false
 ██████╔╝   ██║      ██║   ███████╗██████╔╝██║  ██║███████║███████╗
 ╚═════╝    ╚═╝      ╚═╝   ╚══════╝╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝
 
-Version <version></version> has started at http://example.com:8080
-</pre>
+Version %%bb_version%% has started at http://example.com:8080
+```
 
 ### Unable to start Bytebase with Docker
 

--- a/content/docs/en/get-started/install/overview.md
+++ b/content/docs/en/get-started/install/overview.md
@@ -2,7 +2,7 @@
 title: Deploy to Production
 ---
 
-**Latest release version:** [**<version></version>**](https://github.com/bytebase/bytebase/releases/latest)
+**Latest release version:** [**%%bb_version%%**](https://github.com/bytebase/bytebase/releases/latest)
 
 You have tried Bytebase via [quick start](../quick-start), now it's time to deploy it to production.
 

--- a/content/docs/en/get-started/quick-start.md
+++ b/content/docs/en/get-started/quick-start.md
@@ -2,7 +2,7 @@
 title: 5 Mins Quick Start
 ---
 
-In this guide, you'll use **"Bytebase Test Suite"** to get familiar with the product in the quickest way. This suite includes one Bytebase <version></version> instance and two MySQL 8.0.29 instances.
+In this guide, you'll use **"Bytebase Test Suite"** to get familiar with the product in the quickest way. This suite includes one Bytebase %%bb_version%% instance and two MySQL 8.0.29 instances.
 The task here is to add `nickname` column to `employee` table for both dev and prod environments.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/lav1JaaTLMc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -20,16 +20,16 @@ Before starting, make sure you have installed [Docker](https://www.docker.com/ge
 
 #### MacOS & Linux
 
-<pre>
-curl -fsS https://raw.githubusercontent.com/bytebase/bytebase/main/quickstart/getting-started.docker-compose.yml | BB_VERSION=<version></version> docker-compose -f - up
-</pre>
+```bash
+curl -fsS https://raw.githubusercontent.com/bytebase/bytebase/main/quickstart/getting-started.docker-compose.yml | BB_VERSION=%%bb_version%% docker-compose -f - up
+```
 #### Windows
-<pre>
-BB_VERSION=<version></version>
-</pre>
-<pre>
+```powershell
+BB_VERSION=%%bb_version%%
+```
+```powershell
 curl -fsS https://raw.githubusercontent.com/bytebase/bytebase/main/quickstart/getting-started.docker-compose.yml | docker-compose -f - up
-</pre>
+```
 
 <hint-block type="info">
 
@@ -40,7 +40,7 @@ If the above command doesn't work, replace https://raw.githubusercontent.com/byt
 
 When the Terminal shows the following message, the execution is successful.
 
-<pre>
+```
 employee-prod_1  | 2022-06-21T02:35:01.128005Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.29) starting as process 63
 employee-prod_1  | 2022-06-21T02:35:01.150847Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
 bytebase         | 2022-06-21T02:35:01.449Z	INFO	Completed database initial migration with version 1.1.2.
@@ -56,11 +56,11 @@ bytebase         | ██╔══██╗  ╚██╔╝     ██║   █
 bytebase         | ██████╔╝   ██║      ██║   ███████╗██████╔╝██║  ██║███████║███████╗
 bytebase         | ╚═════╝    ╚═╝      ╚═╝   ╚══════╝╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝
 bytebase         |
-bytebase         | Version <version></version> has started at http://localhost:5678
+bytebase         | Version %%bb_version%% has started at http://localhost:5678
 bytebase         | ___________________________________________________________________________________________
 bytebase         |
 employee-test_1  | [Entrypoint] Database initialized
-</pre>
+```
 
 Now you have three containers running in Docker:
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,6 +9,8 @@ import {
 } from "./common/matrix";
 import { ALPHA_LIST } from "./common/glossary";
 
+const VERSION = fse.readFileSync("VERSION").toString();
+
 function getContentOfNode(node) {
   if (node.type === "text") {
     return node.value;
@@ -399,6 +401,11 @@ export default {
           console.error("Copy failed, err", error);
         }
       },
+    },
+    "content:file:beforeParse": (file) => {
+      if (file.extension === ".md" && file.path.includes("docs")) {
+        file.data = file.data.replace(/%%bb_version%%/g, VERSION);
+      }
     },
     "content:file:beforeInsert": (document) => {
       if (document.extension === ".md") {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "^8.1.1",
     "postcss": "^8.3.5",
-    "raw-loader": "^4.0.2",
     "yaml-loader": "^0.8.0"
   }
 }

--- a/plugin/vue-gtag.ts
+++ b/plugin/vue-gtag.ts
@@ -3,5 +3,5 @@ import VueGtag from "vue-gtag";
 
 Vue.use(VueGtag, {
   config: { id: process.env.gtagKey },
-  appName: "bytebase.com"
+  appName: "bytebase.com",
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,6 @@ specifiers:
   plausible-tracker: ^0.3.5
   postcss: ^8.3.5
   prettier: ^2.6.2
-  raw-loader: ^4.0.2
   remove-markdown: ^0.5.0
   slug: ^5.2.0
   tailwindcss: ^2.2.19
@@ -111,7 +110,6 @@ devDependencies:
   eslint-plugin-prettier: 4.0.0_iqftbjqlxzn3ny5nablrkczhqi
   eslint-plugin-vue: 8.7.1_eslint@8.15.0
   postcss: 8.4.13
-  raw-loader: 4.0.2_webpack@4.46.0
   yaml-loader: 0.8.0
 
 packages:
@@ -5093,7 +5091,7 @@ packages:
       lodash: ^4.17.20
       marko: ^3.14.4
       mote: ^0.2.0
-      mustache: ^4.0.1
+      mustache: ^3.0.0
       nunjucks: ^3.2.2
       plates: ~0.4.11
       pug: ^3.0.0
@@ -10201,17 +10199,6 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
     dev: false
-
-  /raw-loader/4.0.2_webpack@4.46.0:
-    resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      loader-utils: 2.0.2
-      schema-utils: 3.1.1
-      webpack: 4.46.0
-    dev: true
 
   /rc9/1.2.2:
     resolution: {integrity: sha512-zbe8+HR2X28eZepAwohuKkebbEsA67h0DO9I7g12QrHa2CQopR9gztOLPIPXXGTvcxeUjAN4wZ+b29t3m/u05g==}


### PR DESCRIPTION
Use a more elegant way to inject the latest version. Also, this brings back the missing `copy` button in code blocks.

![CleanShot 2022-08-22 at 14 21 54](https://user-images.githubusercontent.com/56376387/185852615-cfe9806e-a4a2-482f-b185-32209e4690c6.png)
