### PR TITLE
chore: rename tenant page title

### DIFF
--- a/content/docs/en/_layout.md
+++ b/content/docs/en/_layout.md
@@ -117,7 +117,7 @@ expand_section_list: ["👀 Introduction", "🐣 Get Started"]
 
 ### [🐞 Troubleshoot](/vcs-integration/troubleshoot)
 
-## [Multi-Tenancy](/tenant-database-management)
+## [Tenant Database Management](/tenant-database-management)
 
 ## Disaster Recovery
 


### PR DESCRIPTION
"Multi-tenancy" means completely different things from what Bytebase provides based on common sense[^1] and our `o/devterm`:

> Multitenancy is a reference to the mode of operation of software where multiple independent instances of one or multiple applications operate in a shared environment.

[^1]: https://www.gartner.com/en/information-technology/glossary/multitenancy