### PR TITLE
chore: expose the sql review github app

### DIFF
--- a/components/SchemaSystem/SchemaConfigurationPage.vue
+++ b/components/SchemaSystem/SchemaConfigurationPage.vue
@@ -1,99 +1,110 @@
 <template>
   <div>
-    <div class="flex justify-end mb-8 gap-x-5">
-      <ActionButton
-        v-if="ruleChanged"
-        :class-names="['bg-white hover:bg-gray-200']"
-        @click="$emit('reset')"
-      >
-        {{ $t("sql-review-guide.reset-changes") }}
-      </ActionButton>
-      <div class="relative z-0 inline-flex shadow-sm rounded-md">
-        <button
-          type="button"
-          class="relative inline-flex items-center px-4 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
-          @click="downloadAsYAML"
+    <div class="flex flex-col items-end mb-8 space-y-3">
+      <div class="flex justify-end gap-x-5">
+        <ActionButton
+          v-if="ruleChanged"
+          :class-names="['bg-white hover:bg-gray-200']"
+          @click="$emit('reset')"
         >
-          {{ $t("sql-review-guide.download-as-yaml") }}
-          <span class="tooltip-wrapper ml-1">
-            <QuestionIcon class="h-5 w-5" />
-            <div class="tooltip-container whitespace-nowrap">
-              <i18n
-                path="sql-review-guide.download-as-yaml-tooltip"
-                tag="span"
-                class="tooltip-content w-full flex flex-row justify-start items-center"
-              >
-                <template #link>
-                  <a
-                    href="https://github.com/marketplace/actions/sql-review"
-                    class="ml-1 flex flex-row justify-start items-center underline hover:opacity-80"
-                    target="_blank"
-                    @click.stop
-                    >SQL Review GitHub Action<svg
-                      class="w-4 h-auto"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                      /></svg
-                  ></a>
-                </template>
-              </i18n>
-            </div>
-          </span>
-        </button>
-        <div class="-ml-px relative block">
+          {{ $t("sql-review-guide.reset-changes") }}
+        </ActionButton>
+        <div class="relative z-0 inline-flex shadow-sm rounded-md">
           <button
-            id="option-menu-button"
             type="button"
-            class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
-            aria-expanded="true"
-            aria-haspopup="true"
-            @click="state.openDownloadMenu = !state.openDownloadMenu"
+            class="relative inline-flex items-center px-4 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+            @click="downloadAsYAML"
           >
-            <span class="sr-only">Open options</span>
-            <!-- Heroicon name: solid/chevron-down -->
-            <svg
-              class="h-5 w-5"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                clip-rule="evenodd"
-              />
-            </svg>
+            {{ $t("sql-review-guide.download-as-yaml") }}
+            <span class="tooltip-wrapper ml-1">
+              <QuestionIcon class="h-5 w-5" />
+              <div class="tooltip-container whitespace-nowrap">
+                <i18n
+                  path="sql-review-guide.download-as-yaml-tooltip"
+                  tag="span"
+                  class="tooltip-content w-full flex flex-row justify-start items-center"
+                >
+                  <template #link>
+                    <a
+                      href="https://github.com/marketplace/actions/sql-review"
+                      class="ml-1 flex flex-row justify-start items-center underline hover:opacity-80"
+                      target="_blank"
+                      @click.stop
+                      >SQL Review GitHub Action<svg
+                        class="w-4 h-auto"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                        /></svg
+                    ></a>
+                  </template>
+                </i18n>
+              </div>
+            </span>
           </button>
-
-          <div
-            v-if="state.openDownloadMenu"
-            class="origin-top-right absolute right-0 mt-2 -mr-1 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none"
-            role="menu"
-            aria-orientation="vertical"
-            aria-labelledby="option-menu-button"
-            tabindex="-1"
-          >
-            <div class="py-1" role="none">
-              <button
-                class="text-gray-700 block px-4 py-2 w-full text-sm hover:bg-gray-100"
-                role="menuitem"
-                tabindex="-1"
-                @click="downloadAsImage"
+          <div class="-ml-px relative block">
+            <button
+              id="option-menu-button"
+              type="button"
+              class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+              aria-expanded="true"
+              aria-haspopup="true"
+              @click="state.openDownloadMenu = !state.openDownloadMenu"
+            >
+              <span class="sr-only">Open options</span>
+              <!-- Heroicon name: solid/chevron-down -->
+              <svg
+                class="h-5 w-5"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
               >
-                {{ $t("sql-review-guide.download-as-image") }}
-              </button>
+                <path
+                  fill-rule="evenodd"
+                  d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </button>
+
+            <div
+              v-if="state.openDownloadMenu"
+              class="origin-top-right absolute right-0 mt-2 -mr-1 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none"
+              role="menu"
+              aria-orientation="vertical"
+              aria-labelledby="option-menu-button"
+              tabindex="-1"
+            >
+              <div class="py-1" role="none">
+                <button
+                  class="text-gray-700 block px-4 py-2 w-full text-sm hover:bg-gray-100"
+                  role="menuitem"
+                  tabindex="-1"
+                  @click="downloadAsImage"
+                >
+                  {{ $t("sql-review-guide.download-as-image") }}
+                </button>
+              </div>
             </div>
           </div>
         </div>
+      </div>
+      <div class="text-gray-700 text-sm font-medium">
+        {{ $t("sql-review-guide.try-our") }}
+        <nuxt-link
+          :to="localePath('/docs/sql-review/sql-advisor/github-app')"
+          class="underline"
+        >
+          {{ $t("sql-review-guide.sql-review-github-app") }}
+        </nuxt-link>
       </div>
     </div>
     <div class="lg:grid lg:grid-cols-6 lg:gap-x-8">

--- a/locales/en.json
+++ b/locales/en.json
@@ -207,7 +207,9 @@
       }
     },
     "configure-rule": "Configure rule",
-    "input-then-press-enter": "Input the value then press enter to add"
+    "input-then-press-enter": "Input the value then press enter to add",
+    "try-our": "Try our",
+    "sql-review-github-app": "SQL Review GitHub App"
   },
   "integration": {
     "dingtalk-feature": "Bytebase supports webhook to post database schema related events to the configured DingTalk group. Those webhook events are specifically customized for DingTalk in order to display the optimal format.",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -207,7 +207,9 @@
         "env": "Dev",
         "title": "SQL 审查规则"
       }
-    }
+    },
+    "try-our": "试试我们的",
+    "sql-review-github-app": "SQL 审核 GitHub 应用"
   },
   "integration": {
     "dingtalk-feature": "Bytebase 支持 webhook 将数据库架构相关的事件发布到配置的钉钉组。 这些 webhook 事件是专门为钉钉定制的，以显示最佳格式。",


### PR DESCRIPTION
As the issue https://linear.app/bytebase/issue/DVM-253/expose-sql-review-action-and-github-app-more-explicitly-in-sql-review said, we should expose the SQL Review GitHub App in SQL Review Guide page.

Sadly I haven’t found a better solution to expose this, so just simply add a sentence below the download button.

<img width="1439" alt="图片" src="https://user-images.githubusercontent.com/10706318/197228491-793dd35f-3542-45c5-96ff-15b2fa7cef33.png">

<img width="1615" alt="图片" src="https://user-images.githubusercontent.com/10706318/197228623-0aebc746-c98e-4e62-b265-08160f22b609.png">

![CleanShot 2022-10-21 at 23 04 37](https://user-images.githubusercontent.com/10706318/197228758-bd712cf1-5109-4bab-a383-0aee43c4dd2b.gif)
