### PR TITLE
docs: restructure tenant database management pages

### DIFF
--- a/content/docs/_layout.md
+++ b/content/docs/_layout.md
@@ -117,7 +117,9 @@ expand_section_list: ["Introduction", "Get Started"]
 
 ### [Troubleshoot](/vcs-integration/troubleshoot)
 
-## [Tenant Database Management](/tenant-database-management)
+## [Tenant Database Management](/tenant-database-management/overview)
+
+### [Tenant Project](/tenant-database-management/tenant-project)
 
 ## Disaster Recovery
 

--- a/content/docs/concepts/tenant-database.md
+++ b/content/docs/concepts/tenant-database.md
@@ -4,14 +4,7 @@ title: Tenant Database
 
 Tenant databases are the homogeneous databases with identical schema in a tenant project. Each individual database corresponds to the combination of a tenant, location, and deployment environment.
 
-Typical scenarios of tenant databases are:
-
-- A Software as a Service (SaaS) provider provides separate database instances for each of its customers (aka. tenants) alongside their application deployments.
-- An internal platform team provides multi-region database deployments (e.g. US, EU), and have separate database instances in different deployment environments (e.g. Staging, Prod).
-
-It is often desired to apply schema changes to databases across all tenants since these databases are homogeneous, but in a staged rollout fashion (aka. canary deployment) to minimize the risk of breaking all deployments.
-
-Bytebase offers all mentioned capability for tenant databases through [Tenant Database Management](/docs/tenant-database-management). 
+Bytebase offers streamlined experience for tenant databases through [Tenant Database Management](/docs/tenant-database-management/overview).
 
 Below is an example showing how a schema change rollout to all tenant databases from **Dev** environment all the way to the **Prod** look like in Bytebase.
 

--- a/content/docs/introduction/use-cases.md
+++ b/content/docs/introduction/use-cases.md
@@ -21,7 +21,7 @@ As the engineering team grows, there will form a platform team or a dedicated DB
 
 ## Multi-Tenant Service
 
-A SaaS service may provision separate [tenant databases](/docs/concepts/tenant-database) for each of its tenants. It's painful and error-prone to make sure a database change is consistently applied to each individual tenant's database. Bytebase provides [management capability](/docs/tenant-database-management) to group those databases and manages the lifecycle of those databases in a single workflow.
+A SaaS service may provision separate [tenant databases](/docs/concepts/tenant-database) for each of its tenants. It's painful and error-prone to make sure a database change is consistently applied to each individual tenant's database. Bytebase provides [management capability](/docs/tenant-database-management/overview) to group those databases and manages the lifecycle of those databases in a single workflow.
 
 ## Schema Enforcement and Engineering Excellence
 

--- a/content/docs/introduction/what-is-bytebase.md
+++ b/content/docs/introduction/what-is-bytebase.md
@@ -33,4 +33,4 @@ Bytebase supports database-level manual and periodical backup.
 
 ### Tenant Database Management
 
-A multi-tenant service may provision separate [tenant databases](/docs/concepts/tenant-database) for each of its tenants. Bytebase comes with the [management capability](/docs/tenant-database-management) to provide robust schema change rollout for all tenants in a single workflow.
+A multi-tenant service may provision separate [tenant databases](/docs/concepts/tenant-database) for each of its tenants. Bytebase comes with the [management capability](/docs/tenant-database-management/overview) to provide robust schema change rollout for all tenants in a single workflow.

--- a/content/docs/tenant-database-management/overview.md
+++ b/content/docs/tenant-database-management/overview.md
@@ -2,8 +2,18 @@
 title: Tenant Database Management
 ---
 
-Tenant Database Management allows database administrators to manage **a collection of databases with identical schemas**.
+Tenant Database Management allows database administrators to manage **a collection of databases with identical schemas**, thses databases are often referred as [tenant databases](/docs/concepts/tenant-database).
 
+Typical scenarios of tenant databases are:
+
+- A Software as a Service (SaaS) provider provides separate database instances for each of its customers (aka. tenants) alongside their application deployments.
+- An internal platform team provides multi-region database deployments (e.g. US, EU), and have separate database instances in different deployment environments (e.g. Staging, Prod).
+
+It is often desired to apply schema changes to databases across all tenants since these databases are homogeneous, but in a staged rollout fashion (aka. canary deployment) to minimize the risk of breaking all deployments.
+
+You can easily manage your tenant databases through [tenant projects](/docs/tenant-database-management/tenant-project) in Bytebase, either for different customer deployments, or different stages for a single team.
+
+You should consider using tenant databases when there are multiple database instances alongside multiple deployments for the same application.
 For example, a software company offers medical record storage services for its customers, hospitals. Each hospital is considered as a tenant, and each tenant has to store their patient data in its own database for regulation or privacy purposes. This feature allows updating database schema for all tenants in a simple and consistent way. Other use cases include multi-location databases for supporting highly-available services where each location is a tenant.
 
 Let's take the hospital example to follow the steps below.

--- a/content/docs/tenant-database-management/overview.md
+++ b/content/docs/tenant-database-management/overview.md
@@ -2,7 +2,7 @@
 title: Tenant Database Management
 ---
 
-Tenant Database Management allows database administrators to manage **a collection of databases with identical schemas**, thses databases are often referred as [tenant databases](/docs/concepts/tenant-database).
+Tenant Database Management allows database administrators to manage **a collection of databases with identical schemas**, these databases are often referred as [tenant databases](/docs/concepts/tenant-database).
 
 Typical scenarios of tenant databases are:
 

--- a/content/docs/tenant-database-management/tenant-project.md
+++ b/content/docs/tenant-database-management/tenant-project.md
@@ -1,0 +1,11 @@
+---
+title: Tenant Project
+---
+
+[Tenant databases](/docs/concepts/tenant-database) are managed through tenant projects in Bytebase.
+
+Tenant projects empowers you to:
+
+1. Roll out schema changes and data updates to mutiple tenant databases by their environments, tenant labels or geolocations, or any combination of them.
+1. Progressively roll out through different stages, and only proceed to the next stage when all of rollouts in the current stage are successful.
+

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -257,7 +257,9 @@
                 </div>
                 <div class="mt-6 lg:text-right">
                   <nuxt-link
-                    :to="localePath('/docs/tenant-database-management')"
+                    :to="
+                      localePath('/docs/tenant-database-management/overview')
+                    "
                     class="inline-flex px-4 py-2 border-2 border-gray-900 text-xl font-medium rounded-md shadow-sm text-gray-900 bg-white"
                     @click="track('docs.tenant-mode')"
                     >{{


### PR DESCRIPTION
This PR breaks down the single-page Tenant Database Management into a directory of pages. This is a first one of a series of PRs, put up these changes because I want to decouple the documentation of the YAML file support from tenant doc overhaul (which takes much longer), so the former can be added as a sub-page in the directory without causing merge conflicts.

---

Part of https://linear.app/bytebase/issue/BYT-1668/tenant-overhaul-related-documentation