### PR TITLE
docs: add warning

### DIFF
--- a/content/docs/administration/webhook-integration/external-approval.md
+++ b/content/docs/administration/webhook-integration/external-approval.md
@@ -40,6 +40,14 @@ In the Manage scopes section of Permissions & Scopes page, add the following sco
 
 ![feishu app permission page](/static/docs/external-approval-feishu-permission.webp)
 
+<hint-block type="warn">
+
+Make sure that you have added all three scopes before moving on.
+
+The "approval:approval" scope may seem to contain "approval:approval:readonly", but you have to add both.
+
+</hint-block>
+
 ### Step 4 - Enable app
 
 In the Version Management & Release page of App Release, create a Version.

--- a/content/docs/administration/webhook-integration/external-approval.md
+++ b/content/docs/administration/webhook-integration/external-approval.md
@@ -42,9 +42,7 @@ In the Manage scopes section of Permissions & Scopes page, add the following sco
 
 <hint-block type="warn">
 
-Make sure that you have added all three scopes before moving on.
-
-The "approval:approval" scope may seem to contain "approval:approval:readonly", but you have to add both.
+Make sure that you have added all three scopes before moving on. In particular, you must add both "approval:approval" and "approval:approval:readonly".
 
 </hint-block>
 


### PR DESCRIPTION
Add a warning because the scope "approval:approval:readonly" is often omitted by users.