### PR TITLE
docs: update website title and remove View all Instance permission for developer

### DIFF
--- a/content/docs/concepts/roles-and-permissions.md
+++ b/content/docs/concepts/roles-and-permissions.md
@@ -47,7 +47,7 @@ By default, the first registered user is granted the `Owner` role, all following
 |                             Edit environment |                           | ✔️  |  ✔️   |
 |                          Reorder environment |                           | ✔️  |  ✔️   |
 |                          Archive environment |                           | ✔️  |  ✔️   |
-|                           View all instances |            ✔️             | ✔️  |  ✔️   |
+|                           View all instances |                           | ✔️  |  ✔️   |
 |                                 Add instance |                           | ✔️  |  ✔️   |
 |                                Edit instance |                           | ✔️  |  ✔️   |
 |                             Archive instance |                           | ✔️  |  ✔️   |

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -124,7 +124,7 @@ export default {
   },
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
-    title: "Bytebase | Database DevOps",
+    title: "Database CI/CD | Database DevOps | Bytebase",
     htmlAttrs: {
       lang: "en",
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -447,13 +447,13 @@ export default defineComponent({
     };
   },
   head: {
-    title: "Bytebase | Database DevOps",
+    title: "Database CI/CD | Database DevOps | Bytebase",
     meta: [
       {
         hid: "bytebase",
-        name: "Bytebase | Database DevOps",
+        name: "Database CI/CD | Database DevOps | Bytebase",
         content:
-          "Bytebase is a database change and version control tool for the DevOps team. It provides a collaboration workspace to help Developers and DBAs manage the database development lifecycle.",
+          "Bytebase is a Database CI/CD tool for DevOps teams. It provides a collaboration workspace to help Developers and DBAs manage the database development lifecycle.",
       },
       {
         hid: "og:image",


### PR DESCRIPTION
* Title from "Bytebase | Database DevOps" to "Database CI/CD | Database DevOps | Bytebase", put features first
* Remove "View all instances" from Workspace Developer permission. Developer doesn't care instance, they only care databases.