### PR TITLE
docs: move terraform to configure part

### DIFF
--- a/content/docs/_layout.md
+++ b/content/docs/_layout.md
@@ -45,15 +45,13 @@ expand_section_list: ["Introduction", "Get Started"]
 
 #### [Customize the Logo](/get-started/configure-workspace/customize-the-logo)
 
-#### [Configure with Terraform](/get-started/configure-workspace/configure-with-terraform)
-
 ### [Work with a Project](/get-started/work-with-a-project/overview)
 
 #### [Create a Project](/get-started/work-with-a-project/create-a-project)
 
 #### [Run a UI Workflow](/get-started/work-with-a-project/run-a-ui-workflow)
 
-
+### [Manage with Terraform](/get-started/terraform)
 ---
 
 ## Concepts

--- a/content/docs/_layout.md
+++ b/content/docs/_layout.md
@@ -45,13 +45,14 @@ expand_section_list: ["Introduction", "Get Started"]
 
 #### [Customize the Logo](/get-started/configure-workspace/customize-the-logo)
 
+#### [Configure with Terraform](/get-started/configure-workspace/configure-with-terraform)
+
 ### [Work with a Project](/get-started/work-with-a-project/overview)
 
 #### [Create a Project](/get-started/work-with-a-project/create-a-project)
 
 #### [Run a UI Workflow](/get-started/work-with-a-project/run-a-ui-workflow)
 
-### [Work with Terraform](/get-started/work-with-terraform/overview)
 
 ---
 

--- a/content/docs/get-started/configure-workspace/configure-with-terraform.md
+++ b/content/docs/get-started/configure-workspace/configure-with-terraform.md
@@ -1,5 +1,5 @@
 ---
-title: Work with Terraform
+title: Configure with Terraform
 ---
 
 Bytebase provides the [Terraform Provider](https://registry.terraform.io/providers/bytebase/bytebase) to let you manage your Bytebase resources via Terraform. Users can use Terraform provider to manage following Bytebase resources:

--- a/content/docs/get-started/terraform.md
+++ b/content/docs/get-started/terraform.md
@@ -1,5 +1,5 @@
 ---
-title: Configure with Terraform
+title: Manage Bytebase with Terraform
 ---
 
 Bytebase provides the [Terraform Provider](https://registry.terraform.io/providers/bytebase/bytebase) to let you manage your Bytebase resources via Terraform. Users can use Terraform provider to manage following Bytebase resources:


### PR DESCRIPTION
We're using terraform to configure workspace-level environment/instance/role. So the doc would better belong to 'Configure  Workspace' Section.