### PR TITLE
docs: update postgres version

### DIFF
--- a/content/docs/get-started/install/external-postgres.md
+++ b/content/docs/get-started/install/external-postgres.md
@@ -8,7 +8,7 @@ Alternatively, you can supply [--pg](/docs/reference/command-line#--pg-string) o
 
 ## Prerequisites
 
-1. PostgreSQL 12 or above.
+1. PostgreSQL 14 or above.
 1. All privileges on the [database object](https://www.postgresql.org/docs/current/sql-grant.html) including:
    - SELECT
    - INSERT


### PR DESCRIPTION
Update the minimum PostgreSQL version in prerequisites to 14.

Because we want to use the jsonb subscription function. https://www.postgresql.org/docs/14/datatype-json.html#JSONB-SUBSCRIPTING