### PR TITLE
fix: mailchimp integration

### DIFF
--- a/components/BookDemoSection.vue
+++ b/components/BookDemoSection.vue
@@ -121,14 +121,19 @@ export default defineComponent({
 
     const subscribe = (e: any) => {
       trackEvent("demo");
-      analytics.value?.identify(email.value, {
-        category: "request-demo",
-        integrations: {
-          MailChimp: {
-            subscriptionStatus: "subscribed",
-          },
+      analytics.value?.identify(
+        email.value,
+        {
+          category: "request-demo",
         },
-      });
+        {
+          integrations: {
+            MailChimp: {
+              subscriptionStatus: "subscribed",
+            },
+          },
+        }
+      );
       subscribed.value = true;
       e.preventDefault();
     };

--- a/components/SubscribeSection.vue
+++ b/components/SubscribeSection.vue
@@ -106,14 +106,19 @@ export default defineComponent({
       trackEvent(props.moduleName);
       // Manually updating user subscription status to re-subscribe
       // Doc: https://segment.com/docs/connections/destinations/catalog/mailchimp/#manually-updating-user-subscription-status
-      analytics.value?.identify(email.value, {
-        category: "subscribe-newsletter",
-        integrations: {
-          MailChimp: {
-            subscriptionStatus: "subscribed",
-          },
+      analytics.value?.identify(
+        email.value,
+        {
+          category: "subscribe-newsletter",
         },
-      });
+        {
+          integrations: {
+            MailChimp: {
+              subscriptionStatus: "subscribed",
+            },
+          },
+        }
+      );
       subscribed.value = true;
       emit("subscribed");
       e.preventDefault();

--- a/pages/demo/index.vue
+++ b/pages/demo/index.vue
@@ -147,14 +147,19 @@ export default defineComponent({
 
     const subscribe = (e: any) => {
       trackEvent("demo");
-      analytics.newsletter.identify(email.value, {
-        category: "request-demo",
-        integrations: {
-          MailChimp: {
-            subscriptionStatus: "subscribed",
-          },
+      analytics.newsletter.identify(
+        email.value,
+        {
+          category: "request-demo",
         },
-      });
+        {
+          integrations: {
+            MailChimp: {
+              subscriptionStatus: "subscribed",
+            },
+          },
+        }
+      );
       subscribed.value = true;
       e.preventDefault();
     };

--- a/plugin/segment.ts
+++ b/plugin/segment.ts
@@ -23,7 +23,7 @@ export const PRICING_EVENT = {
 export interface Metric {
   page: (name: string | null | undefined) => void;
   track: (name: string) => void;
-  identify: (email: string, options: any) => void;
+  identify: (email: string, traits: any, options: any) => void;
 }
 
 const analytics = ref<Metric>();
@@ -58,11 +58,12 @@ class SegmentMetric implements Metric {
     });
   }
 
-  identify(email: string, options: any) {
+  identify(email: string, traits: any, options: any) {
     this.analytics?.identify(
       {
         email: email,
         ...this.metricParamater,
+        ...(traits || {}),
       },
       options
     );


### PR DESCRIPTION
### Issue

Issue https://linear.app/bytebase/issue/BYT-2401/clicking-the-try-now-button-in-team-plan-would-trigger-2-requests-for

The true problem is, the login/sign up in the hub will trigger a "New request for live demo" message to the Lark.

### Background

1. We will send new users in the hub to the newsletter. Issue https://linear.app/bytebase/issue/DVM-372/mailchimp-audience
2. Demo request workflow: Click the button -> Send metric to Segment -> Integrate with MailChimp -> Post webhook to Zapier -> Post webhook to Lark

### Diagnosis

As our newsletter in MailChimp has the Zapier integration, all updates in the newsletter will be sent to the Zapier, then send the "New request for live demo" message to the Lark.

So,
1. Fix the Segment identify func, and ensure we have posted the `category` field to the MailChimp.
<img width="1008" alt="CleanShot 2023-02-01 at 14 06 44@2x" src="https://user-images.githubusercontent.com/10706318/215964735-ad0c9e9b-cb66-4327-b280-542276874807.png">

2. Update the trigger in Zapier, filter inputs by the `category`
<img width="999" alt="CleanShot 2023-02-01 at 13 45 07@2x" src="https://user-images.githubusercontent.com/10706318/215964568-7e293514-9b53-457b-868f-80eb1087022d.png">
