### PR TITLE
docs: fix a broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ If you are interested in contributing, you may take a look at [our online databa
 
 This will fetch the SQL review configuration files before starting the nuxt service, you can check the script [fetch_config_files.sh](./scripts/fetch_config_files.sh) for details.
 
-If you have any problems fetching these files, you could download them manually on the [Bytebase repository](https://github.com/bytebase/bytebase)
+If you have any problems fetching these files, you could download them manually on the [Bytebase repository](https://github.com/bytebase/bytebase).
 
-The SQL review rules are based on the [rule configuration file](https://github.com/bytebase/bytebase/blob/main/frontend/src/types/sqlReviewConfig.yaml) from the Bytebase repository. We need to update that configuration if we want to update the rules.
+The SQL review rules are based on the [rule configuration file](https://github.com/bytebase/bytebase/blob/main/frontend/src/types/sql-review-schema.yaml) from the Bytebase repository. We need to update that configuration if we want to update the rules.


### PR DESCRIPTION
In https://github.com/bytebase/bytebase/pull/2032, [`frontend/src/types/sql-review-schema.yaml`](https://github.com/bytebase/bytebase/blob/main/frontend/src/types/sql-review-schema.yaml) is removed and [`frontend/src/types/sql-review-schema.yaml`](https://github.com/bytebase/bytebase/blob/main/frontend/src/types/sql-review-schema.yaml) is introduced. But the link is not updated in README.

This PR replaces a broken link of rule configuration file with `frontend/src/types/sql-review-schema.yaml`.