### PR TITLE
chore: use Live demo button in the header

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -101,10 +101,19 @@
           </div>
           <div class="transition-all flex flex-row">
             <nuxt-link
-              :to="localePath('/docs/get-started/install/deploy-with-docker')"
-              class="hidden sm:flex ml-2 items-center justify-center whitespace-nowrap px-3 h-7 border border-transparent text-sm font-medium rounded border-gray-200 text-gray-700 bg-gray-100 hover:bg-gray-300"
-              @click.native="track('deploy.header')"
-              >{{ $t("common.self-host") }}</nuxt-link
+              v-if="currentLocale === 'zh'"
+              :to="localePath('/demo')"
+              class="ml-2 flex items-center justify-center whitespace-nowrap px-3 h-7 border border-transparent text-sm font-medium rounded border-gray-200 text-gray-700 bg-gray-100 hover:bg-gray-300"
+              @click.native="track('demo.header')"
+              >{{ $t("common.live-demo") }}</nuxt-link
+            >
+            <a
+              v-else
+              href="https://demo.bytebase.com?ref=bytebase.com"
+              target="_blank"
+              class="ml-2 hidden sm:flex items-center justify-center whitespace-nowrap px-3 h-7 border border-transparent text-sm font-medium rounded border-gray-200 text-gray-700 bg-gray-100 hover:bg-gray-300"
+              @click="track('demo.header')"
+              >{{ $t("common.live-demo") }}</a
             >
             <button
               class="ml-2 flex items-center justify-center whitespace-nowrap px-3 h-7 text-sm font-medium rounded text-white bg-green-500 hover:bg-green-600"

--- a/layouts/content.vue
+++ b/layouts/content.vue
@@ -68,12 +68,14 @@
           @click="toggleSidebar"
         />
         <div v-else class="transition-all flex flex-row">
-          <nuxt-link
-            :to="localePath('/docs/get-started/install/deploy-with-docker')"
-            class="ml-2 flex items-center justify-center whitespace-nowrap px-3 h-7 border border-transparent text-sm font-medium rounded border-gray-200 text-gray-700 bg-gray-100 hover:bg-gray-300"
-            @click.native="track('deploy.header')"
-            >{{ $t("common.self-host") }}</nuxt-link
+          <a
+            href="https://demo.bytebase.com?ref=bytebase.com"
+            target="_blank"
+            class="ml-2 hidden sm:flex items-center justify-center whitespace-nowrap px-3 h-8 border border-transparent text-sm font-medium rounded border-gray-200 text-gray-700 bg-gray-100 hover:bg-gray-300"
+            @click="track('demo.header')"
           >
+            {{ $t("common.live-demo") }}
+          </a>
           <button
             class="ml-2 flex items-center justify-center whitespace-nowrap px-3 h-7 text-sm font-medium rounded text-white bg-green-500 hover:bg-green-600"
             @click="loginToHub"


### PR DESCRIPTION
This is a followup of https://github.com/bytebase/bytebase/pull/5150 and https://github.com/bytebase/bytebase.com/pull/847

With this change, the user journey is: 

* Sign up for Cloud
* Live demo -> self-host / sign up for cloud

So we still expose the live demo to the user.