### PR TITLE
docs: add a demo-confirm page

### DIFF
--- a/pages/demo-confirm.vue
+++ b/pages/demo-confirm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="overflow-hidden">
+  <div class="overflow-hidden my-64">
     <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="relative">
         <h1>

--- a/pages/demo-confirm.vue
+++ b/pages/demo-confirm.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="overflow-hidden">
+    <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="relative">
+        <h1>
+          <span
+            class="block text-5xl text-center text-gray-900 font-extrabold tracking-wide"
+            >Demo Confirmed</span
+          >
+        </h1>
+        <div
+          class="mt-8 max-w-5xl mx-auto text-center text-xl leading-9 text-gray-900"
+        >
+          Thanks for booking time with us. Talk to you soon!
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "@nuxtjs/composition-api";
+
+export default defineComponent({
+  head: {
+    title: "Demo Confirm",
+    meta: [
+      {
+        hid: "Demo Confirm",
+        name: "Demo Confirm",
+        content: "Demo Confirm",
+      },
+    ],
+  },
+});
+</script>


### PR DESCRIPTION
This is a callback page that we can track for Google ads after user books a demo.

![CleanShot 2023-03-22 at 14 50 37](https://user-images.githubusercontent.com/230323/226824248-942d946b-56ac-4a73-b800-3c1bb6bb2c40.png)
