### PR TITLE
chore: redirect contact enterprise to google form

### DIFF
--- a/pages/pricing/index.vue
+++ b/pages/pricing/index.vue
@@ -659,7 +659,7 @@ export default defineComponent({
       } else if (plan.type === PlanType.ENTERPRISE) {
         analytics.value?.track(PRICING_EVENT.ENTERPRISE_PLAN_CLICK);
         window.open(
-          "mailto:support@bytebase.com?subject=Request for enterprise plan"
+          "https://docs.google.com/forms/d/e/1FAIpQLSfe1JvroV4ckBMJo8hDXBYGeuzN0Sn1Ylg1lIUamN2jqu9Fcw/viewform"
         );
       }
     };


### PR DESCRIPTION
the mailto: experience is not inferior as it brings a local default client (user may not have configured one).

Using google form instead, and we will receive webhook event on each request.

We will improve this further after the new website, but good for now.