### PR TITLE
fix: revert demo confirmation page path rename

### DIFF
--- a/src/app/(contact)/confirm-demo/page.tsx
+++ b/src/app/(contact)/confirm-demo/page.tsx
@@ -4,7 +4,7 @@ import Logos from '@/components/pages/contact/logos';
 
 import SEO_DATA from '@/lib/seo-data';
 
-export const metadata = getMetadata(SEO_DATA.DEMO_CONFIRM);
+export const metadata = getMetadata(SEO_DATA.CONFIRM_DEMO);
 
 export default function Page() {
   return (

--- a/src/lib/route.ts
+++ b/src/lib/route.ts
@@ -8,7 +8,7 @@ const Route = {
   SQL_REVIEW_GUIDE: '/sql-review-guide',
   BYTEBASE_PLUS: '/bytebase-plus',
   DEMO: '/request-demo',
-  DEMO_CONFIRM: '/demo-confirm',
+  CONFIRM_DEMO: '/confirm-demo',
 
   // seo pages
   DBA: '/usecase/dba',

--- a/src/lib/seo-data.ts
+++ b/src/lib/seo-data.ts
@@ -76,10 +76,10 @@ const SEO_DATA = {
     description: 'Safer and faster database change and version control for DBAs and Developers',
     pathname: `${Route.DEMO}/`,
   },
-  DEMO_CONFIRM: {
+  CONFIRM_DEMO: {
     title: 'Demo Booking Confirmed',
     description: 'Safer and faster database change and version control for DBAs and Developers',
-    pathname: `${Route.DEMO_CONFIRM}/`,
+    pathname: `${Route.CONFIRM_DEMO}/`,
   },
 };
 


### PR DESCRIPTION
Reason: backward compatibility with the old website isn't needed