### PR TITLE
chore: add separator to docs

### DIFF
--- a/src/components/pages/docs/sidebar/item/item.tsx
+++ b/src/components/pages/docs/sidebar/item/item.tsx
@@ -54,6 +54,14 @@ const Item = ({
 
   const Tag = url ? Link : 'button';
 
+  if (title == '---') {
+    return (
+      <li>
+        <hr className={clsx('mb-2 ml-4 mt-2 w-2/5 opacity-10', '', '')} />
+      </li>
+    );
+  }
+
   return (
     <li
       className={clsx('flex flex-col items-start', depth >= 2 && 'pl-4', !isParentOpen && 'hidden')}
@@ -82,7 +90,6 @@ const Item = ({
         )}
         <span>{title}</span>
       </Tag>
-
       {children && (
         <ul
           className={clsx(

--- a/src/components/pages/docs/sidebar/item/item.tsx
+++ b/src/components/pages/docs/sidebar/item/item.tsx
@@ -57,7 +57,7 @@ const Item = ({
   if (title == '---') {
     return (
       <li>
-        <hr className={clsx('mb-2 ml-4 mt-2 w-2/5 opacity-10', '', '')} />
+        <hr className={clsx('mb-2 ml-4 mt-2 w-2/5 opacity-5', '', '')} />
       </li>
     );
   }

--- a/src/lib/api-docs.ts
+++ b/src/lib/api-docs.ts
@@ -85,7 +85,6 @@ const getSidebar = (): { sidebar: SidebarItem[]; expandedList: string[] } => {
 
   lines.forEach((line) => {
     const [depth, title, url] = parseLine(line);
-
     if (depth !== null) {
       currentSection = { title, url, depth };
       sidebar.push(currentSection);

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -1,6 +1,7 @@
 function parseLine(line: string): [number | null, string | null, string | null] {
   const match = line.match(/^#+\s*\[(.*?)\]\((.*?)\)$/);
   const matchWithoutLink = line.match(/^#+\s*(.*?)$/);
+  const separator = line.match(/^---$/);
 
   if (match) {
     const len = match[0]?.match(/^#+/)?.[0]?.length;
@@ -15,6 +16,8 @@ function parseLine(line: string): [number | null, string | null, string | null] 
     const title = matchWithoutLink[1];
 
     return [depth, title, null];
+  } else if (separator) {
+    return [1, '---', null];
   } else {
     return [null, null, null];
   }


### PR DESCRIPTION
The render part is a bit tricky, it seems some of the tailwind classes will be overwritten. e.g. I can't use `bg-gray-500` to specify the color. To work around, I use `opacity-10` instead.