### PR TITLE
fix: content path resolve

### DIFF
--- a/src/app/(alternative)/schema-migration/flyway-alternative/page.tsx
+++ b/src/app/(alternative)/schema-migration/flyway-alternative/page.tsx
@@ -1,7 +1,6 @@
 import { getBlogPostBySlug } from '@/lib/api-blog';
 import Landing from '@/components/pages/schema-migration/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 import getMetadata from '@/utils/get-metadata';
 import SEO_DATA from '@/lib/seo-data';
 
@@ -16,7 +15,7 @@ const Page = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/app/(alternative)/schema-migration/liquibase-alternative/page.tsx
+++ b/src/app/(alternative)/schema-migration/liquibase-alternative/page.tsx
@@ -1,7 +1,6 @@
 import { getBlogPostBySlug } from '@/lib/api-blog';
 import Landing from '@/components/pages/schema-migration/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 import getMetadata from '@/utils/get-metadata';
 import SEO_DATA from '@/lib/seo-data';
 
@@ -16,7 +15,7 @@ const Page = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/app/(alternative)/sql-editor/datagrip-alternative/page.tsx
+++ b/src/app/(alternative)/sql-editor/datagrip-alternative/page.tsx
@@ -1,7 +1,6 @@
 import { getBlogPostBySlug } from '@/lib/api-blog';
 import Landing from '@/components/pages/sql-editor/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 import getMetadata from '@/utils/get-metadata';
 import SEO_DATA from '@/lib/seo-data';
 
@@ -12,7 +11,7 @@ const Page = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/app/(alternative)/sql-editor/dbeaver-alternative/page.tsx
+++ b/src/app/(alternative)/sql-editor/dbeaver-alternative/page.tsx
@@ -1,7 +1,6 @@
 import { getBlogPostBySlug } from '@/lib/api-blog';
 import Landing from '@/components/pages/sql-editor/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 import getMetadata from '@/utils/get-metadata';
 import SEO_DATA from '@/lib/seo-data';
 
@@ -12,7 +11,7 @@ const Page = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/app/(alternative)/sql-editor/mysql-workbench-alternative/page.tsx
+++ b/src/app/(alternative)/sql-editor/mysql-workbench-alternative/page.tsx
@@ -1,7 +1,6 @@
 import { getBlogPostBySlug } from '@/lib/api-blog';
 import Landing from '@/components/pages/sql-editor/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 import getMetadata from '@/utils/get-metadata';
 import SEO_DATA from '@/lib/seo-data';
 
@@ -12,7 +11,7 @@ const Page = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/app/(alternative)/sql-editor/navicat-alternative/page.tsx
+++ b/src/app/(alternative)/sql-editor/navicat-alternative/page.tsx
@@ -1,7 +1,6 @@
 import { getBlogPostBySlug } from '@/lib/api-blog';
 import Landing from '@/components/pages/sql-editor/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 import getMetadata from '@/utils/get-metadata';
 import SEO_DATA from '@/lib/seo-data';
 
@@ -12,7 +11,7 @@ const Page = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/app/(alternative)/sql-editor/pgadmin-alternative/page.tsx
+++ b/src/app/(alternative)/sql-editor/pgadmin-alternative/page.tsx
@@ -1,7 +1,6 @@
 import { getBlogPostBySlug } from '@/lib/api-blog';
 import Landing from '@/components/pages/sql-editor/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 import getMetadata from '@/utils/get-metadata';
 import SEO_DATA from '@/lib/seo-data';
 
@@ -12,7 +11,7 @@ const Page = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/app/(alternative)/sql-editor/phpmyadmin-alternative/page.tsx
+++ b/src/app/(alternative)/sql-editor/phpmyadmin-alternative/page.tsx
@@ -1,7 +1,6 @@
 import { getBlogPostBySlug } from '@/lib/api-blog';
 import Landing from '@/components/pages/sql-editor/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 import getMetadata from '@/utils/get-metadata';
 import SEO_DATA from '@/lib/seo-data';
 
@@ -12,7 +11,7 @@ const Page = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/app/(alternative)/sql-editor/tableplus-alternative/page.tsx
+++ b/src/app/(alternative)/sql-editor/tableplus-alternative/page.tsx
@@ -1,7 +1,6 @@
 import { getBlogPostBySlug } from '@/lib/api-blog';
 import Landing from '@/components/pages/sql-editor/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 import getMetadata from '@/utils/get-metadata';
 import SEO_DATA from '@/lib/seo-data';
 
@@ -12,7 +11,7 @@ const Page = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -22,7 +22,6 @@ import {
 import { getTableOfContents } from '@/lib/api-docs';
 import Route from '@/lib/route';
 import SEO_DATA from '@/lib/seo-data';
-import CONTENT_FOLDER from '@/lib/content-folder';
 
 export default function Blog({ params }: { params: { slug: string } }) {
   const { slug } = params;
@@ -44,7 +43,7 @@ export default function Blog({ params }: { params: { slug: string } }) {
       </>
     );
   }
-  const post = getBlogPostBySlug(CONTENT_FOLDER.blog, slug);
+  const post = getBlogPostBySlug(slug);
 
   if (!post) return notFound();
 
@@ -86,7 +85,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = params;
 
-  const post = getBlogPostBySlug(CONTENT_FOLDER.blog, slug);
+  const post = getBlogPostBySlug(slug);
 
   if (!post)
     return getMetadata({

--- a/src/app/schema-migration/page.tsx
+++ b/src/app/schema-migration/page.tsx
@@ -4,7 +4,6 @@ import { getBlogPostBySlug } from '@/lib/api-blog';
 import SEO_DATA from '@/lib/seo-data';
 import Landing from '@/components/pages/schema-migration/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 
 export const metadata = getMetadata(SEO_DATA.SCHEMA_MIGRATION);
 
@@ -18,7 +17,7 @@ const SchemaMigrationPage = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/app/sql-editor/page.tsx
+++ b/src/app/sql-editor/page.tsx
@@ -4,7 +4,6 @@ import { getBlogPostBySlug } from '@/lib/api-blog';
 import SEO_DATA from '@/lib/seo-data';
 import Landing from '@/components/pages/sql-editor/landing';
 import { BlogPost } from '@/types/blog-post';
-import CONTENT_FOLDER from '@/lib/content-folder';
 
 export const metadata = getMetadata(SEO_DATA.SQL_EDITOR);
 
@@ -14,7 +13,7 @@ const SQLEditorPage = () => {
   const relatedPosts: BlogPost[] = [];
 
   for (const post of POSTS) {
-    const relatedPost = getBlogPostBySlug(CONTENT_FOLDER.blog, post);
+    const relatedPost = getBlogPostBySlug(post);
     if (relatedPost) {
       relatedPosts.push(relatedPost);
     }

--- a/src/components/shared/content/include-block/include-block.tsx
+++ b/src/components/shared/content/include-block/include-block.tsx
@@ -2,11 +2,10 @@ import Content from '@/components/shared/content';
 
 import { getBlogPostBySlug } from '@/lib/api-blog';
 import { getPostBySlug } from '@/lib/api-docs';
-import CONTENT_FOLDER from '@/lib/content-folder';
 
 const getPost = (url: string) => {
   if (url.startsWith('/blog')) {
-    return getBlogPostBySlug(CONTENT_FOLDER.blog, url);
+    return getBlogPostBySlug(url);
   }
   const docUrl = url.replace('/docs/', '');
   return getPostBySlug(docUrl);

--- a/src/lib/api-blog.ts
+++ b/src/lib/api-blog.ts
@@ -13,8 +13,8 @@ type BlogPostsWithTags = {
 };
 
 const CONTENT_FOLDER = {
-  blog: 'content/blog/',
-  tutorial: 'content/docs/tutorials/',
+  blog: 'content/blog',
+  tutorial: 'content/docs/tutorials',
 };
 
 const getAllBlogPosts = (category?: string): BlogPostsWithTags => {
@@ -22,12 +22,12 @@ const getAllBlogPosts = (category?: string): BlogPostsWithTags => {
     category == 'Tutorial'
       ? `${process.cwd()}/${CONTENT_FOLDER.tutorial}`
       : `${process.cwd()}/${CONTENT_FOLDER.blog}`;
-  const files = glob.sync(`${dir}**/*.md`);
+  const files = glob.sync(`${dir}/**/*.md`);
   const tagsSet = new Set();
 
   const posts: BlogPost[] = files
     .map((file) => {
-      const slug = file.replace(`${dir}`, '').replace('.md', '');
+      const slug = file.replace(`${dir}/`, '').replace('.md', '');
       const post = getPostBySlug(dir, slug);
 
       if (!post || post.tags.includes('Hidden')) return null;

--- a/src/lib/api-changelog.ts
+++ b/src/lib/api-changelog.ts
@@ -1,22 +1,21 @@
 import { getTimeToRead } from '@/utils/get-time-to-read';
 import fs from 'fs';
+import * as glob from 'glob';
 import matter from 'gray-matter';
-import path from 'path';
 
 import { ChangelogPost } from '@/types/changelog-post';
 
-import CONTENT_FOLDER from './content-folder';
-
 const POSTS_PER_PAGE = 20;
 
+const CHANGELOG_DIR_PATH = `${process.cwd()}/content/changelog`;
+
 const getAllChangelogPosts = (): ChangelogPost[] => {
-  const files = fs.readdirSync(CONTENT_FOLDER.changelog).filter((file) => file.endsWith('.md'));
+  const files = glob.sync(`${CHANGELOG_DIR_PATH}/*.md`);
 
   const posts: ChangelogPost[] = files
     .map((file) => {
-      const slug = file.replace('.md', '');
-      const filePath = path.join(CONTENT_FOLDER.changelog, file);
-      const markdownWithMeta = fs.readFileSync(filePath, 'utf-8');
+      const slug = file.replace(`${CHANGELOG_DIR_PATH}/`, '').replace('.md', '');
+      const markdownWithMeta = fs.readFileSync(file, 'utf-8');
       const { content, data } = matter(markdownWithMeta);
 
       if (!data || !content) return null;

--- a/src/lib/content-folder.ts
+++ b/src/lib/content-folder.ts
@@ -1,7 +1,0 @@
-const CONTENT_FOLDER = {
-  blog: 'content/blog/',
-  changelog: 'content/changelog/',
-  tutorial: 'content/docs/tutorials/',
-};
-
-export default CONTENT_FOLDER;


### PR DESCRIPTION
Fix content path not found in `content/blog` and `content/changelog`(found when implementing i18n). And keep it consistency with `content/docs`.

<img width="758" alt="image" src="https://github.com/bytebase/bytebase.com/assets/24653555/6ccf1698-3043-48c3-89a3-216027fd8b53">
