### PR TITLE
fix: Missing <loc>https://www.bytebase.com</loc> in the generated sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,12 +1,20 @@
+const DEFAULT_LANGUAGE = 'en';
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || 'https://www.bytebase.com',
   generateRobotsTxt: true,
   // Custom the i18n path. Remove the prefix `en` for matched path.
   // Reference: https://next-sitemap.iamvishnusankar.com/docs/documentation/custom-transformation
-  transform: async (config, path) => {
-    if (path.startsWith('/en')) {
-      path = path.substring(3);
+
+  transform: (config, path) => {
+    const defaultLanguageNeedle = '/' + DEFAULT_LANGUAGE;
+    const defaultLanguageEnvelopeNeedle = defaultLanguageNeedle + '/';
+    const defaultLanguageNeedleLen = defaultLanguageNeedle.length;
+    if (path.startsWith(defaultLanguageEnvelopeNeedle)) {
+      path = path.substring(defaultLanguageNeedleLen);
+    } else if (path === defaultLanguageNeedle) {
+      path = '/';
     }
 
     return {


### PR DESCRIPTION
I think that the `transform` function in the `next-sitemap.config.js` file is a little bit too aggressive.

Could you check it out?

`CTRL+F` `https://www.bytebase.com<`
https://www.bytebase.com/sitemap-0.xml

Fix proposal: [`46ea2e9`](https://github.com/bytebase/bytebase.com/pull/193/commits/46ea2e98d41c1dd2d126ecce7b0dece2fc29e786)
Related issue: https://github.com/bytebase/bytebase.com/issues/192