### PR TITLE
fix: make healthy check work properly

### DIFF
--- a/content/docs/get-started/install/terminal-docker-run-external-url.md
+++ b/content/docs/get-started/install/terminal-docker-run-external-url.md
@@ -7,9 +7,9 @@ docker run --init \
   --name bytebase \
   --restart always \
   --publish 5678:8080 \
-  --health-cmd "curl --fail http://localhost:5678/healthz || exit 1" \
+  --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" \
   --health-interval 5m \
-  --health-timeout 5m \
+  --health-timeout 10s \
   --volume ~/.bytebase/data:/var/opt/bytebase \
   bytebase/bytebase:%%bb_version%% \
   --data /var/opt/bytebase \

--- a/content/docs/get-started/install/terminal-docker-run.md
+++ b/content/docs/get-started/install/terminal-docker-run.md
@@ -7,9 +7,9 @@ docker run --init \
   --name bytebase \
   --restart always \
   --publish 5678:8080 \
-  --health-cmd "curl --fail http://localhost:5678/healthz || exit 1" \
+  --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" \
   --health-interval 5m \
-  --health-timeout 5m \
+  --health-timeout 10s \
   --volume ~/.bytebase/data:/var/opt/bytebase \
   bytebase/bytebase:%%bb_version%% \
   --data /var/opt/bytebase \

--- a/content/docs/get-started/self-host.md
+++ b/content/docs/get-started/self-host.md
@@ -51,9 +51,9 @@ docker run --init \
   --name bytebase \
   --restart always \
   --publish 80:8080 \
-  --health-cmd "curl --fail http://localhost:80/healthz || exit 1" \
+  --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" \
   --health-interval 5m \
-  --health-timeout 5m \
+  --health-timeout 10s \
   --volume ~/.bytebase/data:/var/opt/bytebase \
   bytebase/bytebase:%%bb_version%% \
   --data /var/opt/bytebase \
@@ -137,7 +137,7 @@ spec:
               port: 8080
             initialDelaySeconds: 300
             periodSeconds: 300
-            timeoutSeconds: 300
+            timeoutSeconds: 10
       volumes:
         - name: data
           emptyDir: {}


### PR DESCRIPTION
The health check command will execute within the container, so we need to access the port that the Bytebase application uses. Additionally, a 10-second timeout should suffice for a basic HTTP request.