### PR TITLE
chore: remove healthcheck in docker run command

### DIFF
--- a/content/blog/global-variable-support-in-nuxt.md
+++ b/content/blog/global-variable-support-in-nuxt.md
@@ -17,9 +17,6 @@ docker run --init \
   --restart always \
   --add-host host.docker.internal:host-gateway \
   --publish 8080:8080 \
-  --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" \
-  --health-interval 5m \
-  --health-timeout 5m \
   --volume ~/.bytebase/data:/var/opt/bytebase \
   bytebase/bytebase:%%bb_version%% \
   --data /var/opt/bytebase \

--- a/content/docs/disaster-recovery/backup.md
+++ b/content/docs/disaster-recovery/backup.md
@@ -94,9 +94,6 @@ docker run --init \
   --name bytebase \
   --restart always \
   --publish 5678:8080 \
-  --health-cmd "curl --fail http://localhost:5678/healthz || exit 1" \
-  --health-interval 5m \
-  --health-timeout 5m \
   --volume ~/.bytebase/data:/var/opt/bytebase \
   --volume ~/.aws:/var/opt/bytebase/.aws \
   bytebase/bytebase:%%bb_version%% \

--- a/content/docs/get-started/install/terminal-docker-run-external-url.md
+++ b/content/docs/get-started/install/terminal-docker-run-external-url.md
@@ -7,9 +7,6 @@ docker run --init \
   --name bytebase \
   --restart always \
   --publish 5678:8080 \
-  --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" \
-  --health-interval 5m \
-  --health-timeout 10s \
   --volume ~/.bytebase/data:/var/opt/bytebase \
   bytebase/bytebase:%%bb_version%% \
   --data /var/opt/bytebase \

--- a/content/docs/get-started/install/terminal-docker-run.md
+++ b/content/docs/get-started/install/terminal-docker-run.md
@@ -7,9 +7,6 @@ docker run --init \
   --name bytebase \
   --restart always \
   --publish 5678:8080 \
-  --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" \
-  --health-interval 5m \
-  --health-timeout 10s \
   --volume ~/.bytebase/data:/var/opt/bytebase \
   bytebase/bytebase:%%bb_version%% \
   --data /var/opt/bytebase \

--- a/content/docs/get-started/self-host.md
+++ b/content/docs/get-started/self-host.md
@@ -51,9 +51,6 @@ docker run --init \
   --name bytebase \
   --restart always \
   --publish 80:8080 \
-  --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" \
-  --health-interval 5m \
-  --health-timeout 10s \
   --volume ~/.bytebase/data:/var/opt/bytebase \
   bytebase/bytebase:%%bb_version%% \
   --data /var/opt/bytebase \


### PR DESCRIPTION
We have already added healthcheck in Dockerfile, so there is no need to add command line parameters in docker run.