### PR TITLE
docs: add `--rm` for docker run

### DIFF
--- a/content/docs/get-started/install/terminal-docker-run.md
+++ b/content/docs/get-started/install/terminal-docker-run.md
@@ -3,7 +3,7 @@ title: Terminal Docker Run
 ---
 
 ```text
-docker run --init \
+docker run --rm --init \
   --name bytebase \
   --publish 8080:8080 \
   --volume ~/.bytebase/data:/var/opt/bytebase \


### PR DESCRIPTION
Use `--rm` to automatically remove the container when it exits. This is helpful in get-started cases.