### PR TITLE
fix: max width of hint block

### DIFF
--- a/src/components/shared/content/hint-block/hint-block.tsx
+++ b/src/components/shared/content/hint-block/hint-block.tsx
@@ -45,7 +45,7 @@ const HintBlock = ({ type, children }: { type: 'info' | 'warning'; children: Rea
 
         <div
           className={clsx(
-            '-mt-2 space-y-2.5 !text-15 !leading-snug prose-p:my-2.5 prose-p:first:mt-0 prose-p:last:mb-0 prose-a:break-all md:-mt-2 sm:-mt-3 sm:!text-14 sm:leading-snug',
+            '-mt-2 max-w-[calc(100%-2em)] space-y-2.5 !text-15 !leading-snug prose-p:my-2.5 prose-p:first:mt-0 prose-p:last:mb-0 prose-a:break-all md:-mt-2 sm:-mt-3 sm:!text-14 sm:leading-snug',
             typeClassNames[type].text,
           )}
         >


### PR DESCRIPTION
### Before

<img width="412" alt="image" src="https://github.com/user-attachments/assets/ecb1c064-1590-4a16-8d47-557dcb0895d2">

### After

<img width="414" alt="image" src="https://github.com/user-attachments/assets/b78215da-6b27-4c9a-9b3a-4e48fdc135b0">
