### PR TITLE
chore: fix code size in headings

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -76,8 +76,8 @@
     h4,
     h5,
     h6 {
-      > code {
-        @apply rounded-md bg-gray-97 px-1.5 py-0.5 font-mono text-gray-15;
+      code {
+        @apply rounded-md bg-gray-97 px-1.5 py-0.5 font-mono text-[1em] text-gray-15;
         font-size: inherit;
 
         &::before,


### PR DESCRIPTION
### Before

<img width="750" alt="image" src="https://github.com/user-attachments/assets/e2d72c4d-eafc-4bdf-96bf-83a6e46e7aaa">

### After

<img width="759" alt="image" src="https://github.com/user-attachments/assets/32c13352-fa7b-46a4-bb9e-256f13666cef">
