### PR TITLE
chore: remove duplicated style definition

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -77,8 +77,7 @@
     h5,
     h6 {
       code {
-        @apply rounded-md bg-gray-97 px-1.5 py-0.5 font-mono text-[1em] text-gray-15;
-        font-size: inherit;
+        @apply rounded-md bg-gray-97 px-1.5 py-0.5 font-mono text-[length:inherit] text-gray-15;
 
         &::before,
         &::after {


### PR DESCRIPTION
following https://github.com/bytebase/bytebase.com/pull/451, use `text-[length:inherit]` instead of `text-[1em]` and `font-size: inherit;`

reference: https://github.com/tailwindlabs/tailwindcss/discussions/10691