### PR TITLE
blogs: mysql vs mariadb (update) - json

### DIFF
--- a/content/blog/mysql-vs-mariadb.md
+++ b/content/blog/mysql-vs-mariadb.md
@@ -65,7 +65,7 @@ MariaDB still relies on the older `.frm` file-based system for table definitions
 
 MySQL has developed robust, native JSON support starting with MySQL 5.7. This includes JSON data types, JSON functions, and indexing mechanisms to efficiently store, query, and manipulate JSON data.
 
-MariaDB can store JSON-like data using standard text fields or its dynamic columns feature, but it lacks the fully integrated JSON support and functions that MySQL offers.
+MariaDB can store JSON data using standard text fields or its dynamic columns feature, but doesn't support MySQL's `->` or `->>` syntax. MariaDB was original behind in JSON functions on offer, but has since offering a comparable set of functions.
 
 ### InnoDB Cluster and Group Replication:
 
@@ -147,6 +147,8 @@ On the other hand, the open-source MariaDB project still carries the torch passe
 It's also possible that MySQL and MariaDB co-exist inside an organization. And if you want to manage the database development lifecycle for both of them, please check out [Bytebase](/).
 
 ![change-query-secure-govern-database-all-in-one](/images/db-scheme-lg.png)
+
+Updated 2024/10/05 - It was noted that MariaDB has equal or better set of JSON functions that MySQL.
 
 ## Other Comparisons
 


### PR DESCRIPTION
Comparing MariaDB json functions to MySQL
* https://mariadb.com/kb/en/json-functions/
* https://dev.mysql.com/doc/refman/9.1/en/json-function-reference.html

There are 4 functions that MariaDB doesn't have that MySQL has being JSON_STORAGE_FREE(), JSON_STORAGE_SIZE(), both unimportant due to MariaDB storing as text, and:
* JSON_SCHEMA_VALIDATION_REPORT
* MEMBER OF().

A look at what MariaDB functions exist that MySQL does not have is:
* JSON_ARRAYAGG
* JSON_COMPACT
* JSON_DETAILED
* JSON_EQUALS
* JSON_EXISTS
* JSON_KEY_VALUE
* JSON_NORMALIZE
* JSON_OBJECT_FILTER_KEYS
* JSON_OBJECT_TO_ARRAY
* JSON_OBJECTAGG

Its a bit hard to argue MariaDB JSON functionality is behind MySQL based on this concrete comparison of features.