### PR TITLE
docs: add ClawCloud Run button

### DIFF
--- a/content/docs/get-started/install/deploy-to-clawcloudrun.md
+++ b/content/docs/get-started/install/deploy-to-clawcloudrun.md
@@ -1,0 +1,21 @@
+---
+title: Deploy to ClawCloud Run
+---
+
+[ClawCloud Run](https://run.claw.cloud/) is a cloud-native deployment platform where users can deploy the application with one click.
+
+## Prerequisites
+
+A ClawCloud Run account (FREE $5 credits ervey month).
+
+## Deploy
+
+1. Click `Run on ClawCloud` to navigate ClawCloud Run platform, and then select "Deploy App" to initiate the deployment process.
+
+   [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=S5I3AOKDXXX0&openapp=system-fastdeploy%3FtemplateName%3Dbytebase)
+
+2. Wait for the deployment to complete. Click "Details" to navigate the application details page, and use the provided "Public Address" to access Bytebase.
+
+3. To modify application configurations, click "Update" on top-right.
+
+4. For more information about ClawCloud Run, see [ClawCloud Run Docs](https://docs.run.claw.cloud/).

--- a/content/docs/get-started/self-host.md
+++ b/content/docs/get-started/self-host.md
@@ -494,3 +494,5 @@ ulimit -n 10240
 - [Deploy to Zeabur](/docs/get-started/install/deploy-to-zeabur/)
 
 - [Deploy to Alibaba Cloud](/docs/get-started/install/deploy-to-alibabacloud/)
+
+- [Deploy to ClawCloud Run](/docs/get-started/install/deploy-to-clawcloudrun/)


### PR DESCRIPTION
docs: add ClawCloud Run button

---
We are **ClawCloud Run** — a cloud-native deployment platform where users can deploy your application with one click. The referral code within the deployment link is just for anonymous traffic analytics in order to improve our platform. If you’d like to use your own code, just sign up on ClawCloud Run and replace it in seconds.