### PR TITLE
docs: consolidate external PostgreSQL configuration into dedicated page

### DIFF
--- a/mintlify/get-started/install/external-postgres.mdx
+++ b/mintlify/get-started/install/external-postgres.mdx
@@ -76,7 +76,7 @@ env:
 
 ### Using Kubernetes Secrets
 
-Instead of specifying PostgreSQL connection string directly in helm or Kubernetes yaml file, you can use Kubernetes secrets resources:
+Instead of specifying PostgreSQL connection string directly in Helm or Kubernetes yaml file, you can use Kubernetes secrets resources:
 
 #### Kubernetes
 

--- a/mintlify/get-started/install/external-postgres.mdx
+++ b/mintlify/get-started/install/external-postgres.mdx
@@ -62,6 +62,39 @@ This bash script demonstrates how to add an external PostgreSQL database as the 
 
 <TerminalDockerRunExternalUrl />
 
+## Kubernetes Configuration
+
+### Using Connection String in YAML
+
+You can specify the PostgreSQL connection string directly in your Kubernetes YAML file:
+
+```yaml
+env:
+  - name: PG_URL
+    value: 'postgresql://<<user>>:<<secret>>@<<host>>:<<port>>/<<dbname>>'
+```
+
+### Using Kubernetes Secrets
+
+Instead of specifying PostgreSQL connection string directly in helm or Kubernetes yaml file, you can use Kubernetes secrets resources:
+
+#### Kubernetes
+
+Use the following yaml section to replace the `spec.templates.spec.containers.env` section:
+
+```yaml
+env:
+  - name: PG_URL
+    valueFrom:
+      secretKeyRef:
+        name: secret_name
+        key: secrete_key
+```
+
+#### Helm
+
+Use `--set bytebase.option.existingPgURLSecret` and `--set bytebase.option.existingPgURLSecretKey` to specify the secret key and secret name instead of `--set "bytebase.option.external-url"={NEW_EXTERNAL_URL}`. See more details in [Bytebase - Artifact Hub](https://artifacthub.io/packages/helm/bytebase/bytebase).
+
 ## Troubleshoot
 
 ### Cannot new server ERROR: syntax error at or near xxx

--- a/mintlify/get-started/install/external-postgres.mdx
+++ b/mintlify/get-started/install/external-postgres.mdx
@@ -88,7 +88,7 @@ env:
     valueFrom:
       secretKeyRef:
         name: secret_name
-        key: secrete_key
+        key: secret_key
 ```
 
 #### Helm

--- a/mintlify/get-started/self-host.mdx
+++ b/mintlify/get-started/self-host.mdx
@@ -187,6 +187,8 @@ spec:
         - name: bytebase
           image: bytebase/bytebase:3.8.1
           imagePullPolicy: Always
+          # Configure external PostgreSQL following the guide:
+          # https://www.bytebase.com/docs/get-started/install/external-postgres
           env:
             - name: PG_URL
               value: 'postgresql://<<user>>:<<secret>>@<<host>>:<<port>>/<<dbname>>'
@@ -342,30 +344,10 @@ spec:
 
 **Note** If you use ingress, make sure to use https to access bytebase;
 
-### External PostgreSQL
-
-Instead of specify PostgreSQL connection string in helm or Kubernetes yaml file, we allows users to using Kubernetes secrets resources.
-
-#### Kubernetes
-
-Using the following yaml section to replace the `spec.templates.spec.containers.env` section:
-
-```yaml
-env:
-  - name: PG_URL
-    valueFrom:
-      secretKeyRef:
-        name: secret_name
-        key: secrete_key
-```
-
-#### Helm
-
-Using `--set bytebase.option.existingPgURLSecret` and `--set bytebase.option.existingPgURLSecretKey` to specify the secret key and secret name instead of `--set "bytebase.option.external-url"={NEW_EXTERNAL_URL}`. See more details in [Bytebase - Artifact Hub](https://artifacthub.io/packages/helm/bytebase/bytebase).
 
 ### Persistent Volume
 
-We don't recommend this. However, if you do not configure [External PostgreSQL](#external-postgresql),
+We don't recommend this. However, if you do not configure [External PostgreSQL](/get-started/install/external-postgres),
 then to persist data, you need to use the [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes) in the cluster. Each cloud provider has its own solution.
 
 #### For Amazon Elastic Kubernetes Service(EKS)


### PR DESCRIPTION
## Summary
- Moved Kubernetes-specific external PostgreSQL configuration from `self-host.mdx` to `external-postgres.mdx`
- Added link from self-host page to the external PostgreSQL documentation
- Improved organization by keeping all external PostgreSQL configuration in one place

## Test plan
- [x] Verify documentation renders correctly
- [x] Check that all links work properly
- [x] Ensure no content was lost during the move

🤖 Generated with [Claude Code](https://claude.ai/code)