### PR TITLE
fix: wrap command-line flags in backticks to prevent em dash conversion

### DIFF
--- a/mintlify/administration/sso/oauth2.mdx
+++ b/mintlify/administration/sso/oauth2.mdx
@@ -53,7 +53,7 @@ The most important information is `Bytebase user's email`. It identifies the Byt
 
 <Note>
 
-OAuth 2.0 usually requires an authorization callback url in the configuration. Please make sure the [--external-url](/get-started/install/external-url) is set correctly.
+OAuth 2.0 usually requires an authorization callback url in the configuration. Please make sure the [`--external-url`](/get-started/install/external-url) is set correctly.
 
 If you start Bytebase with `--external-url http://bytebase.example.com`, then the **authorization callback URL** will be `http://bytebase.example.com/oauth/callback`.
 

--- a/mintlify/changelog/bytebase-1-0-4.mdx
+++ b/mintlify/changelog/bytebase-1-0-4.mdx
@@ -1,19 +1,19 @@
 ---
 title: Bytebase 1.0.4
 updated_at: 2022/04/28 11:29:05
-description: Support --pg option to boot Bytebase. bb CLI Support --dsn option in CLI. Add installation script of bb CLI. Add dashboard page to manage all SQL sheets. Admin page to view all projects. Added /healthz health check endpoint for supporting serverless platform.
+description: Support `--pg` option to boot Bytebase. bb CLI Support `--dsn` option in CLI. Add installation script of bb CLI. Add dashboard page to manage all SQL sheets. Admin page to view all projects. Added /healthz health check endpoint for supporting serverless platform.
 ---
 
 import InstallUpgrade from '/snippets/install/install-upgrade.mdx';
 
 ## Support storing Bytebase metadata in the external PostgreSQL
 
-Use the --pg option to specify the database endpoint upon launching Bytebase.
+Use the `--pg` option to specify the database endpoint upon launching Bytebase.
 ![_](/content/changelog/1.0.4/pg-flag.webp)
 
 ## 🚀  Features
 
-### bb CLI Support --dsn option in CLI
+### bb CLI Support `--dsn` option in CLI
 
 Support data source name (DSN) formats to connect databases in CLI, e.g. `--dsn mysql://user:passwd@host:port/dbname?opt1=val1&opt2=val2`
 

--- a/mintlify/faq.mdx
+++ b/mintlify/faq.mdx
@@ -96,9 +96,9 @@ Debug mode is a global setting and is only supposed to be used for troubleshooti
 
 Debug mode emits more detailed logs on the backend as well as returning more verbose logs to the frontend.
 
-### Enable --debug on startup
+### Enable `--debug` on startup
 
-You can pass [--debug](/reference/command-line#--debug) when starting Bytebase.
+You can pass [`--debug`](/reference/command-line#--debug) when starting Bytebase.
 
 ### Toggle debug mode at runtime
 

--- a/mintlify/get-started/install/external-postgres.mdx
+++ b/mintlify/get-started/install/external-postgres.mdx
@@ -4,7 +4,7 @@ title: Configure External PostgreSQL
 
 import TerminalDockerRunExternalUrl from '/snippets/install/terminal-docker-run-external-url.mdx';
 
-By default, Bytebase bundles an embedded PostgreSQL instance for storing its own metadata. The metadata is stored under the [--data](/reference/command-line#--data-directory) directory.
+By default, Bytebase bundles an embedded PostgreSQL instance for storing its own metadata. The metadata is stored under the [`--data`](/reference/command-line#--data-directory) directory.
 
 **For production setup, you should pass `PG_URL` environment variable to store these metadata in an external PostgreSQL database.**
 

--- a/mintlify/get-started/install/external-url.mdx
+++ b/mintlify/get-started/install/external-url.mdx
@@ -37,13 +37,13 @@ If the exposed port is not 80 or 443, please include the port number in External
 
 ![external-url](/content/docs/get-started/install/external-url.webp)
 
-## Pass --external-url when starting Bytebase
+## Pass `--external-url` when starting Bytebase
 
-[--external-url](/reference/command-line#--external-url-string) can be passed when starting Bytebase.
+[`--external-url`](/reference/command-line#--external-url-string) can be passed when starting Bytebase.
 
 <Note>
 
-This will persist the External URL setting. Thus if Bytebase starts without specifying --external-url
+This will persist the External URL setting. Thus if Bytebase starts without specifying `--external-url`
 next time, the previously passed External URL value will still be there.
 
 </Note>

--- a/mintlify/get-started/step-by-step/add-an-instance.mdx
+++ b/mintlify/get-started/step-by-step/add-an-instance.mdx
@@ -12,7 +12,7 @@ title: 'Step 4: Add an Instance'
 
 <Info>
 
-Bytebase starts two embedded sample PostgreSQL instances accessible from `/tmp:8083` and `/tmp:8084`, you can turn them off by passing [--disable-sample](/reference/command-line/#disable-sample) upon startup.
+Bytebase starts two embedded sample PostgreSQL instances accessible from `/tmp:8083` and `/tmp:8084`, you can turn them off by passing [`--disable-sample`](/reference/command-line/#disable-sample) upon startup.
 
 </Info>
 

--- a/mintlify/get-started/upgrade.mdx
+++ b/mintlify/get-started/upgrade.mdx
@@ -17,7 +17,7 @@ import TerminalDockerRunVolume from '/snippets/install/terminal-docker-run-volum
 
 ### External PostgreSQL Metadata (Recommended)
 
-If [--pg](/reference/command-line#--pg-string) is specified, the metadata will be stored in the specified external PostgreSQL database. Below shows how to back up and restore the Bytebase metadata, let's assume the metadata is stored in `metadb`.
+If [`--pg`](/reference/command-line#--pg-string) is specified, the metadata will be stored in the specified external PostgreSQL database. Below shows how to back up and restore the Bytebase metadata, let's assume the metadata is stored in `metadb`.
 
 #### Back up the metadata
 
@@ -109,14 +109,14 @@ psql -h <<host>> -p <<port>> -U <<user>> postgres -c "DROP DATABASE metadb"
 ### Embedded PostgreSQL Metadata
 
 If [External PostgreSQL](/get-started/install/external-postgres/) is not configured, then
-Bytebase will store the metadata under the [--data](/reference/command-line#--data-directory) directory.
+Bytebase will store the metadata under the [`--data`](/reference/command-line#--data-directory) directory.
 You can back up the `--data` directory or the `pgdata` subfolder.
 
 <Note>
 
-You should periodically back up the entire [--data](/reference/command-line#--data-directory) directory if any data is stored there.
+You should periodically back up the entire [`--data`](/reference/command-line#--data-directory) directory if any data is stored there.
 
-If Bytebase is running and not in the [readonly](/reference/command-line#--readonly) mode, and you want to take the backup, then the underlying data volume must support snapshot feature where the entire directory can take a snapshot at the same time, otherwise it may produce a corrupted backup bundle.
+If Bytebase is running and not in the [`--readonly`](/reference/command-line#--readonly) mode, and you want to take the backup, then the underlying data volume must support snapshot feature where the entire directory can take a snapshot at the same time, otherwise it may produce a corrupted backup bundle.
 
 </Note>
 

--- a/mintlify/reference/command-line.mdx
+++ b/mintlify/reference/command-line.mdx
@@ -23,7 +23,7 @@ Available Commands:
   version     Print the version of Bytebase
 
 Flags:
-      --data string                directory where Bytebase stores metadata if --pg is not specified. If relative path is supplied, then the path is relative to the directory where Bytebase is under (default ".")
+      --data string                directory where Bytebase stores metadata if `--pg` is not specified. If relative path is supplied, then the path is relative to the directory where Bytebase is under (default ".")
       --debug                      whether to enable debug level logging
       --demo string                name of the demo to use. If specified, Bytebase will run in demo mode
       --disable-metric             disable the metric collector
@@ -34,41 +34,41 @@ Flags:
       --port int                   port where Bytebase server runs. Default to 8080 (default 8080)
 ```
 
-## --data &lt;&lt;directory&gt;&gt;
+## `--data` &lt;&lt;directory&gt;&gt;
 
 default: **.**
 
-The directory where Bytebase stores its own data if [--pg](#pg-string) is not specified. The directory must exist beforehand, otherwise Bytebase will fail to start. If &lt;&lt;directory&gt;&gt; is a relative path, then it's relative to the directory where the bytebase binary runs.
+The directory where Bytebase stores its own data if [`--pg`](#pg-string) is not specified. The directory must exist beforehand, otherwise Bytebase will fail to start. If &lt;&lt;directory&gt;&gt; is a relative path, then it's relative to the directory where the bytebase binary runs.
 
-## --debug
+## `--debug`
 
 default: **false**
 
 If specified, Bytebase will emit more logs, this is only used when troubleshooting Bytebase issues.
 
-## --disable-metric
+## `--disable-metric`
 
 default: **false**
 
 If specified, Bytebase will not collect usage metric.
 
-## --disable-sample
+## `--disable-sample`
 
 default: **false**
 
 If specified, Bytebase will not start sample Postgres instance.
 
-## --demo &lt;&lt;string&gt;&gt;
+## `--demo` &lt;&lt;string&gt;&gt;
 
 default: **""**
 
-The demo name. If specified, Bytebase will load the demo data instead of the real data. The data is the same used by [the demo](https://www.bytebase.com/view-live-demo). This is a quick way to test the product yourself or demonstrate it to your peers. When Bytebase is started with --demo, it stores the data in a separate location, which means the demo data and real data never interferes with each other.
+The demo name. If specified, Bytebase will load the demo data instead of the real data. The data is the same used by [the demo](https://www.bytebase.com/view-live-demo). This is a quick way to test the product yourself or demonstrate it to your peers. When Bytebase is started with `--demo`, it stores the data in a separate location, which means the demo data and real data never interferes with each other.
 
 The current available demo names are:
 
 - default
 
-## --external-url &lt;&lt;string&gt;&gt;
+## `--external-url` &lt;&lt;string&gt;&gt;
 
 default: **[/get-started/install/external-url](https://www.bytebase.com/docs/get-started/install/external-url)**
 
@@ -76,7 +76,7 @@ The external URL where user visits Bytebase, must start with `http://` or `https
 
 See [Configure External URL](/get-started/install/external-url).
 
-## --pg &lt;&lt;string&gt;&gt;
+## `--pg` &lt;&lt;string&gt;&gt;
 
 default: **""**
 
@@ -90,7 +90,7 @@ Alternatively, you can also pass PG_URL environment variable.
 
 </Tip>
 
-## --port &lt;&lt;number&gt;&gt;
+## `--port` &lt;&lt;number&gt;&gt;
 
 default: **8080**
 


### PR DESCRIPTION
## Summary
- Fixed Mintlify's typography processing converting double dashes (--) to em dashes (—) for command-line flags
- Wrapped all command-line flags in backticks to maintain correct formatting on docs.bytebase.com
- Ensures flags like `--pg`, `--data`, `--external-url` display correctly instead of showing as "—pg", "—data", "—external-url"

## Changes
- Wrapped all Bytebase CLI flags in backticks throughout documentation
- Updated flag references in documentation and changelogs  
- Fixed section headers in command-line reference to include backticks

## Test plan
- [x] Verified all instances of command-line flags are now wrapped in backticks
- [x] Checked that Docker/Kubernetes command flags inside code blocks remain unchanged
- [x] Ensured SQL comments with "--" are not affected
- [ ] Preview changes on Mintlify to confirm double dashes display correctly

## Files affected
- `/get-started/upgrade.mdx`
- `/get-started/step-by-step/add-an-instance.mdx`
- `/get-started/install/external-url.mdx`
- `/get-started/install/external-postgres.mdx`
- `/reference/command-line.mdx`
- `/faq.mdx`
- `/changelog/bytebase-1-0-4.mdx`
- `/administration/sso/oauth2.mdx`

🤖 Generated with [Claude Code](https://claude.ai/code)