### PR TITLE
fix: correct broken documentation links and remove Fargate option

### DIFF
--- a/mintlify/faq.mdx
+++ b/mintlify/faq.mdx
@@ -45,7 +45,7 @@ If you use Docker to deploy Bytebase, please use Docker version >= [20.10.24](ht
 
 ### WebSocket
 
-SQL Editor autocomplete requires [enabling WebSocket](/get-started/deploy-with-docker/#enable-websocket-for-sql-editor) in your gateway if present.
+SQL Editor autocomplete requires [enabling WebSocket](/get-started/self-host/external-access#websocket-support) in your gateway if present.
 
 ## Does Bytebase retain your data
 

--- a/mintlify/get-started/self-host/production-setup.mdx
+++ b/mintlify/get-started/self-host/production-setup.mdx
@@ -8,7 +8,7 @@ This page describes how to set up Bytebase in production environment.
 
 ## Enable HTTPS and WebSocket
 
-You can use [Caddy](https://caddyserver.com/docs/quick-starts/reverse-proxy) or [Nginx](https://www.nginx.com/). Check out the [configuration example](/get-started/deploy-with-docker/#configuration).
+You can use [Caddy](https://caddyserver.com/docs/quick-starts/reverse-proxy) or [Nginx](https://www.nginx.com/). Check out the [configuration example](/get-started/self-host/external-access).
 
 ## Configure External URL
 
@@ -53,7 +53,6 @@ If you self-host Bytebase in the cloud provider, below is the recommended stack.
 
 - EC2 + RDS for PostgreSQL.
 - ECS/EKS + RDS for PostgreSQL.
-- [Fargate + RDS for PostgreSQL](/get-started/deploy-with-docker/#aws-fargate).
 
 ### GCP
 

--- a/mintlify/get-started/step-by-step/deploy-with-docker.mdx
+++ b/mintlify/get-started/step-by-step/deploy-with-docker.mdx
@@ -13,7 +13,7 @@ import TerminalDockerRunVolume from '/snippets/install/terminal-docker-run-volum
 
 <TutorialBlock url="/docs/tutorials/first-schema-change" title="First Schema Change in 5 Minutes" />
 
-It's recommended to [run Bytebase with Docker](/get-started/deploy-with-docker) which is the easiest way to get you started.
+It's recommended to [run Bytebase with Docker](/get-started/self-host/deploy-with-docker) which is the easiest way to get you started.
 
 Run the following command to start Bytebase on container port `8080` and map it to localhost port `8080`.
 

--- a/mintlify/onboarding/poc.mdx
+++ b/mintlify/onboarding/poc.mdx
@@ -10,7 +10,7 @@ enterprise license.
 ## Install
 
 - [System Requirements](/faq/##system-requirements)
-- [Docker](/get-started/deploy-with-docker), [Kubernetes](/get-started/deploy-with-kubernetes)
+- [Docker](/get-started/self-host/deploy-with-docker), [Kubernetes](/get-started/self-host/deploy-with-kubernetes)
 - [Production Setup](/get-started/self-host/production-setup)
 
 ## Understand Permission Model

--- a/mintlify/snippets/install/install-upgrade.mdx
+++ b/mintlify/snippets/install/install-upgrade.mdx
@@ -4,8 +4,8 @@ title: Install and Upgrade
 
 ## ⚙️ Install and Upgrade
 
-- Fresh install: [/get-started/deploy-with-docker](/get-started/deploy-with-docker)
+- Fresh install: [/get-started/self-host/deploy-with-docker](/get-started/self-host/deploy-with-docker)
 
-- Upgrade: [/get-started/upgrade](/get-started/upgrade)
+- Upgrade: [/get-started/self-host/upgrade](/get-started/self-host/upgrade)
 
 _Warning 1): Bytebase does not support in-place downgrade. Make sure to back up your metadata before upgrading. 2) Never run multiple containers on the same data directory. Stop and remove the old one first to avoid corruption._


### PR DESCRIPTION
## Summary
- Fixed broken internal documentation links by adding missing `/self-host/` subdirectory to paths
- Removed AWS Fargate deployment option from production setup guide
- Corrected anchor links pointing to wrong documentation sections

## Changes Made

### Fixed Broken Links
- `faq.mdx`: Updated WebSocket configuration link to point to correct external-access page
- `production-setup.mdx`: Fixed configuration example link and removed Fargate reference
- `step-by-step/deploy-with-docker.mdx`: Added `/self-host/` to Docker deployment link
- `poc.mdx`: Updated Docker and Kubernetes links with `/self-host/` prefix
- `snippets/install/install-upgrade.mdx`: Fixed installation and upgrade links

### Removed Features
- Removed AWS Fargate deployment option from the AWS section in production setup documentation

## Test Plan
- [x] Verified all modified links now point to existing documentation pages
- [x] Checked that anchor links reference valid sections in target documents
- [x] Confirmed Fargate references have been removed

🤖 Generated with [Claude Code](https://claude.ai/code)