### PR TITLE
docs: move Terraform overview from Install to Integrations section

### DIFF
--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -43,8 +43,7 @@
                 ]
               },
               "get-started/cloud",
-              "get-started/instance",
-              "integrations/terraform/overview"
+              "get-started/instance"
             ]
           },
           {
@@ -251,6 +250,12 @@
               "integrations/api/permission",
               "integrations/api/data-classification",
               "integrations/api/audit-log"
+            ]
+          },
+          {
+            "group": "Infrastructure as Code",
+            "pages": [
+              "integrations/terraform/overview"
             ]
           },
           {


### PR DESCRIPTION
## Summary
- Moved `integrations/terraform/overview` from the Install section to a new Infrastructure as Code group under Integrations
- Positioned the Infrastructure as Code group between API and 3rd Party groups based on importance hierarchy

## Test plan
- [ ] Verify navigation structure renders correctly in Mintlify
- [ ] Check that Terraform overview page is accessible from new location
- [ ] Confirm no broken links to the old location

🤖 Generated with [Claude Code](https://claude.ai/code)