### PR TITLE
docs: fix broken link

### DIFF
--- a/mintlify/changelog/bytebase-2-7-0.mdx
+++ b/mintlify/changelog/bytebase-2-7-0.mdx
@@ -17,7 +17,7 @@ import InstallUpgrade from '/snippets/install/install-upgrade.mdx';
 
 - Revamped UI for database change issue.
 - SQL Review: support configuring separate settings for different database engines.
-- Provide [arm64 Docker image](/get-started/deploy-with-docker/).
+- Provide [arm64 Docker image](/get-started/self-host/deploy-with-docker).
 
 ## 🎠 Community
 

--- a/mintlify/get-started/self-host-vs-cloud.mdx
+++ b/mintlify/get-started/self-host-vs-cloud.mdx
@@ -63,7 +63,7 @@ description: Choose the right Bytebase deployment for your databases
 ## How to Deploy
 
 <CardGroup cols={2}>
-  <Card title="Self-Host Guide" href="/get-started/deploy-with-docker" icon="server">
+  <Card title="Self-Host Guide" href="/get-started/self-host/deploy-with-docker" icon="server">
     Deploy with Docker in 5 minutes
   </Card>
 


### PR DESCRIPTION
Found by `mint broken-links`

The API doc issues are false alerts.

``bash
% mint broken-links
Checking for broken links...

integrations/api/audit-log.mdx
  /api-reference/auditlogservice/post-v1auditlogs:search 
  
integrations/api/authentication.mdx
  /api-reference/authservice/post-v1authlogin 
  
integrations/api/data-classification.mdx
  /api-reference/settingservice/patch-v1settings
  /api-reference/databaseservice/patch-v1instances-databases 
  
integrations/api/issue.mdx
  /api-reference/issueservice/post-v1projects-issues 
  
integrations/api/permission.mdx
  /api-reference/workspaceservice/get-v1workspaces-:getIamPolicy
  /api-reference/projectservice/get-v1projects-:getIamPolicy
  /api-reference/roleservice/get-v1roles
  /api-reference/userservice/get-v1users
  /api-reference/groupservice/get-v1groups 
  
integrations/api/plan.mdx
  /api-reference/planservice/post-v1projects-plans
  /api-reference/sheetservice/post-v1projects-sheets 
  
integrations/api/release.mdx
  /api-reference/releaseservice/post-v1projects-releases 
  
integrations/api/rollout.mdx
  /api-reference/rolloutservice/post-v1projects-rollouts 
  
integrations/api/sql-review.mdx
  /api-reference/releaseservice/post-v1projects-releases:check
  /api-reference/sqlservice/post-v1sqlcheck 
  
16 broken links found.
```