### PR TITLE
docs: remove Baseline Migration section from change workflow documentation

### DIFF
--- a/mintlify/change-database/change-workflow.mdx
+++ b/mintlify/change-database/change-workflow.mdx
@@ -109,6 +109,3 @@ Schema migration is the migration type for DDL statements.
 
 Data migration is the migration type for DML statements.
 
-### Baseline Migration
-
-Baseline migration instructs Bytebase to use the latest live schema as the source of truth. This is normally used when [schema drift](/change-database/drift-detection) occurs and Bytebase needs to re-establish the baseline based on the latest live schema.


### PR DESCRIPTION
## Summary
- Removed the Baseline Migration section from the change workflow documentation as requested

## Changes
- Deleted the Baseline Migration subsection under Migration Types in `/mintlify/change-database/change-workflow.mdx`

🤖 Generated with [Claude Code](https://claude.ai/code)