### PR TITLE
docs: reorganize navigation - move watermark and audit log to General group

### DIFF
--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -201,23 +201,23 @@
               },
               "administration/user-groups",
               "administration/roles",
-              "security/audit-log",
               "administration/scim/overview",
               "administration/2fa",
               "administration/password",
-              "administration/sign-in-restriction",
-              "security/watermark"
+              "administration/sign-in-restriction"
             ]
           },
           {
             "group": "General",
             "pages": [
+              "security/audit-log",
               "administration/license",
               "administration/mode",
               "ai-assistant",
               "administration/instance",
               "administration/environment-policy/overview",
               "administration/customize-logo",
+              "security/watermark",
               "administration/announcement",
               "administration/archive"
             ]


### PR DESCRIPTION
## Summary
- Moved "security/watermark" from Security group to General group
- Moved "security/audit-log" from Security group to General group

These documentation navigation items are now better organized under the General section rather than Security.

## Test plan
- [ ] Verify documentation navigation renders correctly
- [ ] Confirm both items appear in the General section
- [ ] Check that Security section no longer contains these items

🤖 Generated with [Claude Code](https://claude.ai/code)