### PR TITLE
docs: reorganize Cloud page position in navigation

### DIFF
--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -30,6 +30,7 @@
             "group": "Install",
             "pages": [
               "get-started/self-host-vs-cloud",
+              "get-started/cloud",
               {
                 "group": "Self-Host",
                 "pages": [
@@ -41,8 +42,7 @@
                   "get-started/self-host/production-setup",
                   "get-started/self-host/upgrade"
                 ]
-              },
-              "get-started/cloud"
+              }
             ]
           },
           {


### PR DESCRIPTION
## Summary
- Moved the Cloud installation page to appear before the Self-Host section in the Install group
- Improves navigation flow by presenting simpler cloud option before more complex self-hosting setup

## Test plan
- [ ] Verify the navigation renders correctly in development (`mint dev`)
- [ ] Check that all links work properly after reorganization
- [ ] Confirm the Cloud page appears before Self-Host in the navigation menu

🤖 Generated with [Claude Code](https://claude.ai/code)