### PR TITLE
docs: add GitOps release examples for CI/CD platforms

### DIFF
--- a/mintlify/gitops/release.mdx
+++ b/mintlify/gitops/release.mdx
@@ -2,66 +2,39 @@
 title: Release
 ---
 
-Bytebase integrates with popular CI/CD platforms to automate database releases through GitOps workflows.
+Bytebase integrates with popular CI/CD platforms to automate database releases through GitOps workflows. When triggered by your CI/CD pipeline, Bytebase creates a **release** - an immutable package containing all your SQL migration files that can be progressively deployed across environments.
 
-## Release Workflow
+## Setup
 
-When triggered by your CI/CD pipeline, Bytebase automatically creates a **release** - an immutable package containing all your SQL migration files. This release can then be progressively deployed across your database environments (test → staging → production), ensuring consistent and traceable database changes.
+Before creating releases:
 
-## GitHub Actions
+1. [Install GitOps Integration](/gitops/installation) - Connect Bytebase to your VCS
+2. [Configure Database Environments](/administration/environment) - Set up your database environments (test, staging, production)
 
-<Card
-  title="Tutorial: Database GitOps with GitHub Actions"
-  icon="graduation-cap"
-  href="/tutorials/gitops-github-workflow/"
-  horizontal
-/>
+## Examples
 
-<Note>
+We provide examples for GitHub, GitLab, Bitbucket, and Azure DevOps below. Adjust the parameters to match your repository structure and rollout workflow.
 
-To reach your self-hosted Bytebase from GitHub Actions, you can choose either options:
+## GitHub
 
-1. Tunnel GitHub Actions using [Cloudflare Zero Trust](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) with [Cloudflare Warp GitHub Actions](https://github.com/marketplace/actions/setup-cloudflare-warp).
+<Card title="Tutorial: Database GitOps with GitHub Actions" icon="graduation-cap" href="/tutorials/gitops-github-workflow/" horizontal />
 
-1. Use [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners).
+<Card title="Example: GitHub Actions Release Workflow" icon="code" href="https://github.com/bytebase/example-gitops-github-flow/blob/main/.github/workflows/release-action.yml" horizontal />
 
-</Note>
+## GitLab
 
-Bytebase provides pre-built [GitHub Actions](https://github.com/marketplace?query=bytebase&type=actions) to ease the GitHub integration.
+<Card title="Tutorial: Database GitOps with GitLab CI" icon="graduation-cap" href="/tutorials/gitops-gitlab-workflow/" horizontal />
 
-## GitLab CI
+<Card title="Example: GitLab CI Rollout Pipeline" icon="code" href="https://gitlab.com/bytebase-sample/gitops-example/-/blob/main/bytebase-rollout.yml" horizontal />
 
-<Card
-  title="Tutorial: Database GitOps with GitLab CI"
-  icon="graduation-cap"
-  href="/tutorials/gitops-gitlab-workflow/"
-  horizontal
-/>
+## Bitbucket
 
-<Note>
+<Card title="Tutorial: Database GitOps with Bitbucket Pipelines" icon="graduation-cap" href="/tutorials/gitops-bitbucket-workflow/" horizontal />
 
-If you're using **self-hosted GitLab** in an internal network:
+<Card title="Example: Bitbucket Pipelines Configuration" icon="code" href="https://bitbucket.org/p0nyyy/cicd/src/main/bitbucket-pipelines.yml" horizontal />
 
-1. You'll need to [manually load the `bytebase/bytebase-action` image](/tutorials/gitops-gitlab-workflow#use-bytebase-action-in-an-offline-gitlab-runner) into your internal Docker registry.
+## Azure DevOps
 
-1. Set the [`clone_url` in GitLab Runner](/tutorials/gitops-gitlab-workflow#resolve-gitlab-clone-redirect-in-internal-network) to avoid redirection to external addresses.
+<Card title="Tutorial: Database GitOps with Azure DevOps Pipeline" icon="graduation-cap" href="/tutorials/gitops-azure-devops-workflow/" horizontal />
 
-</Note>
-
-## Bitbucket Pipelines
-
-<Card
-  title="Tutorial: Database GitOps with Bitbucket Pipelines"
-  icon="graduation-cap"
-  href="/tutorials/gitops-bitbucket-workflow/"
-  horizontal
-/>
-
-## Azure DevOps Pipeline
-
-<Card
-  title="Tutorial: Database GitOps with Azure DevOps Pipeline"
-  icon="graduation-cap"
-  href="/tutorials/gitops-azure-devops-workflow/"
-  horizontal
-/>
+<Card title="Example: Azure DevOps Release Pipeline" icon="code" href="https://dev.azure.com/bytebase-hq/_git/bytebase-example?path=/pipelines/rollout-release.yml" horizontal />


### PR DESCRIPTION
## Summary
- Add example workflow/pipeline links for GitHub, GitLab, Bitbucket, and Azure DevOps to the release documentation
- Restructure release.mdx to match the format of sql-review-ci.mdx for consistency
- Add setup prerequisites section with links to relevant documentation

## Changes
- Added example configuration links for each CI/CD platform:
  - GitHub Actions: Release workflow example
  - GitLab CI: Rollout pipeline example  
  - Bitbucket: Pipelines configuration example
  - Azure DevOps: Release pipeline example
- Restructured the document to include Setup and Examples sections
- Removed platform-specific notes to keep documentation concise and maintainable

🤖 Generated with [Claude Code](https://claude.ai/code)